### PR TITLE
add missing query param

### DIFF
--- a/src/ws/WSHandler.cpp
+++ b/src/ws/WSHandler.cpp
@@ -77,12 +77,16 @@ std::string generate_sec_accept_value(const std::string& sec_ws_key)
     return std::string((char*)x64_encode_buf, x64_encode_len);
 }
 
-std::string WSHandler::buildUpgradeRequest(const std::string& path, const std::string& host,
+std::string WSHandler::buildUpgradeRequest(const std::string& path, const std::string& query, const std::string& host,
                                     const std::string& proto, const std::string& origin)
 {
     std::stringstream ss;
     ss << "GET ";
     ss << path;
+    if(!query.empty()){
+        ss << "?";
+        ss << query;
+    }
     ss << " HTTP/1.1\r\n";
     ss << "Host: " << host << "\r\n";
     ss << "Upgrade: websocket\r\n";

--- a/src/ws/WSHandler.h
+++ b/src/ws/WSHandler.h
@@ -67,7 +67,7 @@ public:
     void setMode(WSMode mode) { mode_ = mode; }
     WSMode getMode() { return mode_; }
     void setHttpParser(HttpParser::Impl&& parser);
-    std::string buildUpgradeRequest(const std::string& path, const std::string& host,
+    std::string buildUpgradeRequest(const std::string& path, const std::string& query, const std::string& host,
                              const std::string& proto, const std::string& origin);
     std::string buildUpgradeResponse();
     

--- a/src/ws/WebSocketImpl.cpp
+++ b/src/ws/WebSocketImpl.cpp
@@ -232,7 +232,7 @@ void WebSocket::Impl::onError(KMError err)
 
 void WebSocket::Impl::sendUpgradeRequest()
 {
-    std::string str(ws_handler_.buildUpgradeRequest(uri_.getPath(), uri_.getHost(), proto_, origin_));
+    std::string str(ws_handler_.buildUpgradeRequest(uri_.getPath(), uri_.getQuery(), uri_.getHost(), proto_, origin_));
     setState(State::UPGRADING);
     TcpConnection::send((const uint8_t*)str.c_str(), str.size());
 }


### PR DESCRIPTION
missing query param, eg. connect server with url like 'wss://192.168.1.124:443/?peerName=1212', websocket server can't get '?peerName=1212'