### PR TITLE
HTTP proxy support

### DIFF
--- a/bld/ios/kuma.xcodeproj/project.pbxproj
+++ b/bld/ios/kuma.xcodeproj/project.pbxproj
@@ -40,6 +40,9 @@
 		6F84E98A1D5B032D00AF8E3B /* HPackTable.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 6F84E9861D5B032D00AF8E3B /* HPackTable.cpp */; };
 		6F87763B1EACEA10002F1165 /* DnsResolver.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 6F8776391EACEA10002F1165 /* DnsResolver.cpp */; };
 		6F8906F922630D06004D0DE9 /* H1xStream.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 6F8906F822630D06004D0DE9 /* H1xStream.cpp */; };
+		6F8BE43C22951AF800E6EA32 /* BasicAuthenticator.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 6F8BE43722951AF700E6EA32 /* BasicAuthenticator.cpp */; };
+		6F8BE43D22951AF800E6EA32 /* ProxyConnectionImpl.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 6F8BE43822951AF700E6EA32 /* ProxyConnectionImpl.cpp */; };
+		6F8BE43E22951AF800E6EA32 /* ProxyAuthenticator.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 6F8BE43A22951AF700E6EA32 /* ProxyAuthenticator.cpp */; };
 		6F91F1751D782EF8004A95B9 /* Http1xRequest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 6F91F1731D782EF8004A95B9 /* Http1xRequest.cpp */; };
 		6F91F1771D782F1A004A95B9 /* Notifier.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 6F91F1761D782F1A004A95B9 /* Notifier.cpp */; };
 		6F91F1B41D7B29CB004A95B9 /* KQueue.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 6F91F1B31D7B29CB004A95B9 /* KQueue.cpp */; };
@@ -177,6 +180,13 @@
 		6F87763A1EACEA10002F1165 /* DnsResolver.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = DnsResolver.h; path = ../../src/DnsResolver.h; sourceTree = "<group>"; };
 		6F8906F722630D05004D0DE9 /* H1xStream.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = H1xStream.h; sourceTree = "<group>"; };
 		6F8906F822630D06004D0DE9 /* H1xStream.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = H1xStream.cpp; sourceTree = "<group>"; };
+		6F8BE43522951AF700E6EA32 /* BasicAuthenticator.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BasicAuthenticator.h; sourceTree = "<group>"; };
+		6F8BE43622951AF700E6EA32 /* proxydefs.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = proxydefs.h; sourceTree = "<group>"; };
+		6F8BE43722951AF700E6EA32 /* BasicAuthenticator.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = BasicAuthenticator.cpp; sourceTree = "<group>"; };
+		6F8BE43822951AF700E6EA32 /* ProxyConnectionImpl.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ProxyConnectionImpl.cpp; sourceTree = "<group>"; };
+		6F8BE43922951AF700E6EA32 /* ProxyConnectionImpl.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ProxyConnectionImpl.h; sourceTree = "<group>"; };
+		6F8BE43A22951AF700E6EA32 /* ProxyAuthenticator.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ProxyAuthenticator.cpp; sourceTree = "<group>"; };
+		6F8BE43B22951AF700E6EA32 /* ProxyAuthenticator.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ProxyAuthenticator.h; sourceTree = "<group>"; };
 		6F91F1731D782EF8004A95B9 /* Http1xRequest.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Http1xRequest.cpp; sourceTree = "<group>"; };
 		6F91F1741D782EF8004A95B9 /* Http1xRequest.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Http1xRequest.h; sourceTree = "<group>"; };
 		6F91F1761D782F1A004A95B9 /* Notifier.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Notifier.cpp; sourceTree = "<group>"; };
@@ -300,6 +310,7 @@
 		6F7D5FD31B33EC43000FF2F8 /* kuma */ = {
 			isa = PBXGroup;
 			children = (
+				6F8BE43422951AC000E6EA32 /* proxy */,
 				6FD7C54C221965830005DDFF /* compr */,
 				6FECECF81C21383900310F52 /* http */,
 				6FECED081C21396F00310F52 /* poll */,
@@ -380,6 +391,21 @@
 				6F84E9881D5B032D00AF8E3B /* StaticTable.h */,
 			);
 			path = hpack;
+			sourceTree = "<group>";
+		};
+		6F8BE43422951AC000E6EA32 /* proxy */ = {
+			isa = PBXGroup;
+			children = (
+				6F8BE43722951AF700E6EA32 /* BasicAuthenticator.cpp */,
+				6F8BE43522951AF700E6EA32 /* BasicAuthenticator.h */,
+				6F8BE43A22951AF700E6EA32 /* ProxyAuthenticator.cpp */,
+				6F8BE43B22951AF700E6EA32 /* ProxyAuthenticator.h */,
+				6F8BE43822951AF700E6EA32 /* ProxyConnectionImpl.cpp */,
+				6F8BE43922951AF700E6EA32 /* ProxyConnectionImpl.h */,
+				6F8BE43622951AF700E6EA32 /* proxydefs.h */,
+			);
+			name = proxy;
+			path = ../../src/proxy;
 			sourceTree = "<group>";
 		};
 		6FD7C46022129B300005DDFF /* zlib */ = {
@@ -637,6 +663,7 @@
 				6F6D148D1D9D098C008B64E6 /* FlowControl.cpp in Sources */,
 				6FECED1D1C2139CA00310F52 /* kmtrace.cpp in Sources */,
 				6FD7D0B32244DE460005DDFF /* WSConnection_v2.cpp in Sources */,
+				6F8BE43E22951AF800E6EA32 /* ProxyAuthenticator.cpp in Sources */,
 				6F27331D1EC75579006E221E /* BioHandler.cpp in Sources */,
 				6FECED0E1C2139A400310F52 /* VPoll.cpp in Sources */,
 				6F84E97E1D5B031300AF8E3B /* H2ConnectionMgr.cpp in Sources */,
@@ -653,6 +680,7 @@
 				6FD7C46F22129C100005DDFF /* crc32.c in Sources */,
 				6FD7CB9D22323C140005DDFF /* httputils.cpp in Sources */,
 				6FECED231C2139D600310F52 /* WebSocketImpl.cpp in Sources */,
+				6F8BE43D22951AF800E6EA32 /* ProxyConnectionImpl.cpp in Sources */,
 				6FD7C47122129C100005DDFF /* trees.c in Sources */,
 				6F66AC3D1C71B03F00BB37B9 /* TcpListenerImpl.cpp in Sources */,
 				6FECED031C2138E700310F52 /* HttpResponseImpl.cpp in Sources */,
@@ -671,6 +699,7 @@
 				6F7D5FE91B33EC65000FF2F8 /* TimerManager.cpp in Sources */,
 				6F7FC6881F4D82550038360B /* h2utils.cpp in Sources */,
 				6F87763B1EACEA10002F1165 /* DnsResolver.cpp in Sources */,
+				6F8BE43C22951AF800E6EA32 /* BasicAuthenticator.cpp in Sources */,
 				6F84E97F1D5B031300AF8E3B /* H2Frame.cpp in Sources */,
 				6F7BBB3E1ED57DF00093BDE3 /* UdpSocketBase.cpp in Sources */,
 				6FD7C47522129C100005DDFF /* infback.c in Sources */,

--- a/bld/msvc/kuma.vcxproj
+++ b/bld/msvc/kuma.vcxproj
@@ -206,6 +206,10 @@
     <ClCompile Include="..\..\src\poll\Notifier.cpp" />
     <ClCompile Include="..\..\src\poll\SelectPoll.cpp" />
     <ClCompile Include="..\..\src\poll\VPoll.cpp" />
+    <ClCompile Include="..\..\src\proxy\BasicAuthenticator.cpp" />
+    <ClCompile Include="..\..\src\proxy\ProxyAuthenticator.cpp" />
+    <ClCompile Include="..\..\src\proxy\ProxyConnection.cpp" />
+    <ClCompile Include="..\..\src\proxy\SspiAuthenticator.cpp" />
     <ClCompile Include="..\..\src\SocketBase.cpp" />
     <ClCompile Include="..\..\src\ssl\BioHandler.cpp" />
     <ClCompile Include="..\..\src\ssl\OpenSslLib.cpp" />
@@ -287,6 +291,10 @@
     <ClInclude Include="..\..\src\kmdefs.h" />
     <ClInclude Include="..\..\src\poll\IOPoll.h" />
     <ClInclude Include="..\..\src\poll\Notifier.h" />
+    <ClInclude Include="..\..\src\proxy\BasicAuthenticator.h" />
+    <ClInclude Include="..\..\src\proxy\ProxyAuthenticator.h" />
+    <ClInclude Include="..\..\src\proxy\ProxyConnection.h" />
+    <ClInclude Include="..\..\src\proxy\SspiAuthenticator.h" />
     <ClInclude Include="..\..\src\SocketBase.h" />
     <ClInclude Include="..\..\src\ssl\BioHandler.h" />
     <ClInclude Include="..\..\src\ssl\OpenSslLib.h" />

--- a/bld/msvc/kuma.vcxproj
+++ b/bld/msvc/kuma.vcxproj
@@ -208,7 +208,7 @@
     <ClCompile Include="..\..\src\poll\VPoll.cpp" />
     <ClCompile Include="..\..\src\proxy\BasicAuthenticator.cpp" />
     <ClCompile Include="..\..\src\proxy\ProxyAuthenticator.cpp" />
-    <ClCompile Include="..\..\src\proxy\ProxyConnection.cpp" />
+    <ClCompile Include="..\..\src\proxy\ProxyConnectionImpl.cpp" />
     <ClCompile Include="..\..\src\proxy\SspiAuthenticator.cpp" />
     <ClCompile Include="..\..\src\SocketBase.cpp" />
     <ClCompile Include="..\..\src\ssl\BioHandler.cpp" />
@@ -293,7 +293,7 @@
     <ClInclude Include="..\..\src\poll\Notifier.h" />
     <ClInclude Include="..\..\src\proxy\BasicAuthenticator.h" />
     <ClInclude Include="..\..\src\proxy\ProxyAuthenticator.h" />
-    <ClInclude Include="..\..\src\proxy\ProxyConnection.h" />
+    <ClInclude Include="..\..\src\proxy\ProxyConnectionImpl.h" />
     <ClInclude Include="..\..\src\proxy\SspiAuthenticator.h" />
     <ClInclude Include="..\..\src\SocketBase.h" />
     <ClInclude Include="..\..\src\ssl\BioHandler.h" />

--- a/bld/msvc/kuma.vcxproj.filters
+++ b/bld/msvc/kuma.vcxproj.filters
@@ -291,9 +291,6 @@
     <ClCompile Include="..\..\src\http\H1xStream.cpp">
       <Filter>Source Files\http</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\src\proxy\ProxyConnection.cpp">
-      <Filter>Source Files\proxy</Filter>
-    </ClCompile>
     <ClCompile Include="..\..\src\proxy\ProxyAuthenticator.cpp">
       <Filter>Source Files\proxy</Filter>
     </ClCompile>
@@ -301,6 +298,9 @@
       <Filter>Source Files\proxy</Filter>
     </ClCompile>
     <ClCompile Include="..\..\src\proxy\SspiAuthenticator.cpp">
+      <Filter>Source Files\proxy</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\proxy\ProxyConnectionImpl.cpp">
       <Filter>Source Files\proxy</Filter>
     </ClCompile>
   </ItemGroup>
@@ -512,9 +512,6 @@
     <ClInclude Include="..\..\src\http\H1xStream.h">
       <Filter>Header Files\http</Filter>
     </ClInclude>
-    <ClInclude Include="..\..\src\proxy\ProxyConnection.h">
-      <Filter>Source Files\proxy</Filter>
-    </ClInclude>
     <ClInclude Include="..\..\src\proxy\ProxyAuthenticator.h">
       <Filter>Source Files\proxy</Filter>
     </ClInclude>
@@ -522,6 +519,9 @@
       <Filter>Source Files\proxy</Filter>
     </ClInclude>
     <ClInclude Include="..\..\src\proxy\SspiAuthenticator.h">
+      <Filter>Source Files\proxy</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\proxy\ProxyConnectionImpl.h">
       <Filter>Source Files\proxy</Filter>
     </ClInclude>
   </ItemGroup>

--- a/bld/msvc/kuma.vcxproj.filters
+++ b/bld/msvc/kuma.vcxproj.filters
@@ -70,6 +70,9 @@
     <Filter Include="Source Files\compr">
       <UniqueIdentifier>{32bb0506-8263-4fc2-a942-64672c48b332}</UniqueIdentifier>
     </Filter>
+    <Filter Include="Source Files\proxy">
+      <UniqueIdentifier>{e7c39218-61b1-4f94-ac78-40d5b64f7a47}</UniqueIdentifier>
+    </Filter>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="..\..\src\EventLoopImpl.cpp">
@@ -288,6 +291,18 @@
     <ClCompile Include="..\..\src\http\H1xStream.cpp">
       <Filter>Source Files\http</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\proxy\ProxyConnection.cpp">
+      <Filter>Source Files\proxy</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\proxy\ProxyAuthenticator.cpp">
+      <Filter>Source Files\proxy</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\proxy\BasicAuthenticator.cpp">
+      <Filter>Source Files\proxy</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\proxy\SspiAuthenticator.cpp">
+      <Filter>Source Files\proxy</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\src\kmconf.h">
@@ -496,6 +511,18 @@
     </ClInclude>
     <ClInclude Include="..\..\src\http\H1xStream.h">
       <Filter>Header Files\http</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\proxy\ProxyConnection.h">
+      <Filter>Source Files\proxy</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\proxy\ProxyAuthenticator.h">
+      <Filter>Source Files\proxy</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\proxy\BasicAuthenticator.h">
+      <Filter>Source Files\proxy</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\proxy\SspiAuthenticator.h">
+      <Filter>Source Files\proxy</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>

--- a/bld/osx/kuma.xcodeproj/project.pbxproj
+++ b/bld/osx/kuma.xcodeproj/project.pbxproj
@@ -28,8 +28,8 @@
 		6F472B311D43B53500D01201 /* TcpConnection.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 6F472B2F1D43B53500D01201 /* TcpConnection.cpp */; };
 		6F472B321D43B53500D01201 /* TcpConnection.h in Headers */ = {isa = PBXBuildFile; fileRef = 6F472B301D43B53500D01201 /* TcpConnection.h */; };
 		6F4D603D1B9FCA61009132AF /* CoreFoundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6F4D603C1B9FCA61009132AF /* CoreFoundation.framework */; };
-		6F54A1CA2273DFC400729E9A /* ProxyConnection.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 6F54A1C82273DFC400729E9A /* ProxyConnection.cpp */; };
-		6F54A1CB2273DFC400729E9A /* ProxyConnection.h in Headers */ = {isa = PBXBuildFile; fileRef = 6F54A1C92273DFC400729E9A /* ProxyConnection.h */; };
+		6F54A1CA2273DFC400729E9A /* ProxyConnectionImpl.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 6F54A1C82273DFC400729E9A /* ProxyConnectionImpl.cpp */; };
+		6F54A1CB2273DFC400729E9A /* ProxyConnectionImpl.h in Headers */ = {isa = PBXBuildFile; fileRef = 6F54A1C92273DFC400729E9A /* ProxyConnectionImpl.h */; };
 		6F54A2B42275705400729E9A /* ProxyAuthenticator.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 6F54A2B22275705400729E9A /* ProxyAuthenticator.cpp */; };
 		6F54A2B52275705400729E9A /* ProxyAuthenticator.h in Headers */ = {isa = PBXBuildFile; fileRef = 6F54A2B32275705400729E9A /* ProxyAuthenticator.h */; };
 		6F54A30122758DC900729E9A /* GSS.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6F54A30022758DC900729E9A /* GSS.framework */; };
@@ -67,6 +67,7 @@
 		6F8776001EAB4B18002F1165 /* DnsResolver.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 6F8775FF1EAB4B18002F1165 /* DnsResolver.cpp */; };
 		6F890533225AEE65004D0DE9 /* H1xStream.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 6F890531225AEE65004D0DE9 /* H1xStream.cpp */; };
 		6F890534225AEE65004D0DE9 /* H1xStream.h in Headers */ = {isa = PBXBuildFile; fileRef = 6F890532225AEE65004D0DE9 /* H1xStream.h */; };
+		6F8BE42E2294EEAB00E6EA32 /* proxydefs.h in Headers */ = {isa = PBXBuildFile; fileRef = 6F8BE42D2294EEAB00E6EA32 /* proxydefs.h */; };
 		6F91F1711D782DD3004A95B9 /* Http1xRequest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 6F91F16F1D782DD3004A95B9 /* Http1xRequest.cpp */; };
 		6F91F1721D782DD3004A95B9 /* Http1xRequest.h in Headers */ = {isa = PBXBuildFile; fileRef = 6F91F1701D782DD3004A95B9 /* Http1xRequest.h */; };
 		6F91F1B21D7ADF77004A95B9 /* KQueue.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 6F91F1B11D7ADF77004A95B9 /* KQueue.cpp */; };
@@ -150,8 +151,8 @@
 		6FF211D91B1556FB006603BB /* EventLoopImpl.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 6FF211D61B1556FB006603BB /* EventLoopImpl.cpp */; };
 		6FF211DA1B1556FB006603BB /* EventLoopImpl.h in Headers */ = {isa = PBXBuildFile; fileRef = 6FF211D71B1556FB006603BB /* EventLoopImpl.h */; };
 		6FF212931B181103006603BB /* kmapi.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 6FF212921B181103006603BB /* kmapi.cpp */; };
-		6FF252A12289712900663403 /* GssAuthenticator.h in Headers */ = {isa = PBXBuildFile; fileRef = 6FF2529F2289712900663403 /* GssAuthenticator.h */; };
-		6FF252A22289712900663403 /* GssAuthenticator.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 6FF252A02289712900663403 /* GssAuthenticator.cpp */; };
+		6FF252A12289712900663403 /* GssapiAuthenticator.h in Headers */ = {isa = PBXBuildFile; fileRef = 6FF2529F2289712900663403 /* GssapiAuthenticator.h */; };
+		6FF252A22289712900663403 /* GssapiAuthenticator.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 6FF252A02289712900663403 /* GssapiAuthenticator.cpp */; };
 		6FF252A6228A570500663403 /* BasicAuthenticator.h in Headers */ = {isa = PBXBuildFile; fileRef = 6FF252A4228A570500663403 /* BasicAuthenticator.h */; };
 		6FF252A7228A570500663403 /* BasicAuthenticator.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 6FF252A5228A570500663403 /* BasicAuthenticator.cpp */; };
 		6FF7478D1B29587D0007F34D /* base64.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 6FF7478B1B29587D0007F34D /* base64.cpp */; };
@@ -182,8 +183,8 @@
 		6F472B2F1D43B53500D01201 /* TcpConnection.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = TcpConnection.cpp; sourceTree = "<group>"; };
 		6F472B301D43B53500D01201 /* TcpConnection.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TcpConnection.h; sourceTree = "<group>"; };
 		6F4D603C1B9FCA61009132AF /* CoreFoundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreFoundation.framework; path = System/Library/Frameworks/CoreFoundation.framework; sourceTree = SDKROOT; };
-		6F54A1C82273DFC400729E9A /* ProxyConnection.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ProxyConnection.cpp; sourceTree = "<group>"; };
-		6F54A1C92273DFC400729E9A /* ProxyConnection.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ProxyConnection.h; sourceTree = "<group>"; };
+		6F54A1C82273DFC400729E9A /* ProxyConnectionImpl.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ProxyConnectionImpl.cpp; sourceTree = "<group>"; };
+		6F54A1C92273DFC400729E9A /* ProxyConnectionImpl.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ProxyConnectionImpl.h; sourceTree = "<group>"; };
 		6F54A2B22275705400729E9A /* ProxyAuthenticator.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ProxyAuthenticator.cpp; sourceTree = "<group>"; };
 		6F54A2B32275705400729E9A /* ProxyAuthenticator.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ProxyAuthenticator.h; sourceTree = "<group>"; };
 		6F54A30022758DC900729E9A /* GSS.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = GSS.framework; path = System/Library/Frameworks/GSS.framework; sourceTree = SDKROOT; };
@@ -224,6 +225,7 @@
 		6F8775FF1EAB4B18002F1165 /* DnsResolver.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = DnsResolver.cpp; sourceTree = "<group>"; };
 		6F890531225AEE65004D0DE9 /* H1xStream.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = H1xStream.cpp; sourceTree = "<group>"; };
 		6F890532225AEE65004D0DE9 /* H1xStream.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = H1xStream.h; sourceTree = "<group>"; };
+		6F8BE42D2294EEAB00E6EA32 /* proxydefs.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = proxydefs.h; sourceTree = "<group>"; };
 		6F91F16F1D782DD3004A95B9 /* Http1xRequest.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Http1xRequest.cpp; sourceTree = "<group>"; };
 		6F91F1701D782DD3004A95B9 /* Http1xRequest.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Http1xRequest.h; sourceTree = "<group>"; };
 		6F91F1B11D7ADF77004A95B9 /* KQueue.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = KQueue.cpp; sourceTree = "<group>"; };
@@ -308,8 +310,8 @@
 		6FF211D61B1556FB006603BB /* EventLoopImpl.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = EventLoopImpl.cpp; sourceTree = "<group>"; };
 		6FF211D71B1556FB006603BB /* EventLoopImpl.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = EventLoopImpl.h; sourceTree = "<group>"; };
 		6FF212921B181103006603BB /* kmapi.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = kmapi.cpp; sourceTree = "<group>"; };
-		6FF2529F2289712900663403 /* GssAuthenticator.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GssAuthenticator.h; sourceTree = "<group>"; };
-		6FF252A02289712900663403 /* GssAuthenticator.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = GssAuthenticator.cpp; sourceTree = "<group>"; };
+		6FF2529F2289712900663403 /* GssapiAuthenticator.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GssapiAuthenticator.h; sourceTree = "<group>"; };
+		6FF252A02289712900663403 /* GssapiAuthenticator.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = GssapiAuthenticator.cpp; sourceTree = "<group>"; };
 		6FF252A4228A570500663403 /* BasicAuthenticator.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BasicAuthenticator.h; sourceTree = "<group>"; };
 		6FF252A5228A570500663403 /* BasicAuthenticator.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = BasicAuthenticator.cpp; sourceTree = "<group>"; };
 		6FF7478B1B29587D0007F34D /* base64.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = base64.cpp; sourceTree = "<group>"; };
@@ -347,14 +349,15 @@
 		6F54A1C72273DF8B00729E9A /* proxy */ = {
 			isa = PBXGroup;
 			children = (
+				6F8BE42D2294EEAB00E6EA32 /* proxydefs.h */,
 				6FF252A5228A570500663403 /* BasicAuthenticator.cpp */,
 				6FF252A4228A570500663403 /* BasicAuthenticator.h */,
-				6FF252A02289712900663403 /* GssAuthenticator.cpp */,
-				6FF2529F2289712900663403 /* GssAuthenticator.h */,
+				6FF252A02289712900663403 /* GssapiAuthenticator.cpp */,
+				6FF2529F2289712900663403 /* GssapiAuthenticator.h */,
 				6F54A2B22275705400729E9A /* ProxyAuthenticator.cpp */,
 				6F54A2B32275705400729E9A /* ProxyAuthenticator.h */,
-				6F54A1C82273DFC400729E9A /* ProxyConnection.cpp */,
-				6F54A1C92273DFC400729E9A /* ProxyConnection.h */,
+				6F54A1C82273DFC400729E9A /* ProxyConnectionImpl.cpp */,
+				6F54A1C92273DFC400729E9A /* ProxyConnectionImpl.h */,
 			);
 			path = proxy;
 			sourceTree = "<group>";
@@ -666,7 +669,7 @@
 				6FBB2C911D139C430024550F /* Notifier.h in Headers */,
 				6F2963541A18AB0D00C3C79B /* kmtrace.h in Headers */,
 				6F890534225AEE65004D0DE9 /* H1xStream.h in Headers */,
-				6FF252A12289712900663403 /* GssAuthenticator.h in Headers */,
+				6FF252A12289712900663403 /* GssapiAuthenticator.h in Headers */,
 				6FE0EF0A1D409863006136B7 /* Http2Request.h in Headers */,
 				6FD3F0F01EC06FE70027D04F /* skbuffer.h in Headers */,
 				6FE0EF0E1D409863006136B7 /* H2Stream.h in Headers */,
@@ -683,12 +686,13 @@
 				6FD7CBED223394BB0005DDFF /* WSConnection.h in Headers */,
 				6F35E21B1F96ECAB005F705B /* defer.h in Headers */,
 				6F6D12EF1D965A9D008B64E6 /* Http1xResponse.h in Headers */,
+				6F8BE42E2294EEAB00E6EA32 /* proxydefs.h in Headers */,
 				6F7BBB381ED57B0A0093BDE3 /* UdpSocketBase.h in Headers */,
 				6FBB2CBF1D139C990024550F /* WSHandler.h in Headers */,
 				6FF211D81B1556FB006603BB /* evdefs.h in Headers */,
 				6FE0EF151D40986D006136B7 /* HPacker.h in Headers */,
 				6F2D40481B194AE200E24928 /* TimerManager.h in Headers */,
-				6F54A1CB2273DFC400729E9A /* ProxyConnection.h in Headers */,
+				6F54A1CB2273DFC400729E9A /* ProxyConnectionImpl.h in Headers */,
 				6F2732A41EC44A16006E221E /* SocketBase.h in Headers */,
 				6FBB2CAD1D139C560024550F /* HttpResponseImpl.h in Headers */,
 				6FD7C54A221965360005DDFF /* compr.h in Headers */,
@@ -799,11 +803,11 @@
 				6FBB2CBE1D139C990024550F /* WSHandler.cpp in Sources */,
 				6F2D40471B194AE200E24928 /* TimerManager.cpp in Sources */,
 				6F2733251EC7DF00006E221E /* SslHandler.cpp in Sources */,
-				6FF252A22289712900663403 /* GssAuthenticator.cpp in Sources */,
+				6FF252A22289712900663403 /* GssapiAuthenticator.cpp in Sources */,
 				6F6D12EE1D965A9D008B64E6 /* Http1xResponse.cpp in Sources */,
 				6F2963531A18AB0D00C3C79B /* kmtrace.cpp in Sources */,
 				6F8776001EAB4B18002F1165 /* DnsResolver.cpp in Sources */,
-				6F54A1CA2273DFC400729E9A /* ProxyConnection.cpp in Sources */,
+				6F54A1CA2273DFC400729E9A /* ProxyConnectionImpl.cpp in Sources */,
 				6F7BBB371ED57B0A0093BDE3 /* UdpSocketBase.cpp in Sources */,
 				6FE0EF071D409863006136B7 /* H2Frame.cpp in Sources */,
 				6FF211D91B1556FB006603BB /* EventLoopImpl.cpp in Sources */,

--- a/bld/osx/kuma.xcodeproj/project.pbxproj
+++ b/bld/osx/kuma.xcodeproj/project.pbxproj
@@ -28,6 +28,11 @@
 		6F472B311D43B53500D01201 /* TcpConnection.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 6F472B2F1D43B53500D01201 /* TcpConnection.cpp */; };
 		6F472B321D43B53500D01201 /* TcpConnection.h in Headers */ = {isa = PBXBuildFile; fileRef = 6F472B301D43B53500D01201 /* TcpConnection.h */; };
 		6F4D603D1B9FCA61009132AF /* CoreFoundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6F4D603C1B9FCA61009132AF /* CoreFoundation.framework */; };
+		6F54A1CA2273DFC400729E9A /* ProxyConnection.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 6F54A1C82273DFC400729E9A /* ProxyConnection.cpp */; };
+		6F54A1CB2273DFC400729E9A /* ProxyConnection.h in Headers */ = {isa = PBXBuildFile; fileRef = 6F54A1C92273DFC400729E9A /* ProxyConnection.h */; };
+		6F54A2B42275705400729E9A /* ProxyAuthenticator.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 6F54A2B22275705400729E9A /* ProxyAuthenticator.cpp */; };
+		6F54A2B52275705400729E9A /* ProxyAuthenticator.h in Headers */ = {isa = PBXBuildFile; fileRef = 6F54A2B32275705400729E9A /* ProxyAuthenticator.h */; };
+		6F54A30122758DC900729E9A /* GSS.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6F54A30022758DC900729E9A /* GSS.framework */; };
 		6F5C79E21D59CC8700FF8C83 /* DestroyDetector.h in Headers */ = {isa = PBXBuildFile; fileRef = 6F5C79E11D59CC8700FF8C83 /* DestroyDetector.h */; };
 		6F6208FB1A26BDB1000DAF4B /* kmconf.h in Headers */ = {isa = PBXBuildFile; fileRef = 6F6208F81A26BDB1000DAF4B /* kmconf.h */; };
 		6F6208FD1A26BDB1000DAF4B /* kmapi.h in Headers */ = {isa = PBXBuildFile; fileRef = 6F6208FA1A26BDB1000DAF4B /* kmapi.h */; };
@@ -145,6 +150,10 @@
 		6FF211D91B1556FB006603BB /* EventLoopImpl.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 6FF211D61B1556FB006603BB /* EventLoopImpl.cpp */; };
 		6FF211DA1B1556FB006603BB /* EventLoopImpl.h in Headers */ = {isa = PBXBuildFile; fileRef = 6FF211D71B1556FB006603BB /* EventLoopImpl.h */; };
 		6FF212931B181103006603BB /* kmapi.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 6FF212921B181103006603BB /* kmapi.cpp */; };
+		6FF252A12289712900663403 /* GssAuthenticator.h in Headers */ = {isa = PBXBuildFile; fileRef = 6FF2529F2289712900663403 /* GssAuthenticator.h */; };
+		6FF252A22289712900663403 /* GssAuthenticator.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 6FF252A02289712900663403 /* GssAuthenticator.cpp */; };
+		6FF252A6228A570500663403 /* BasicAuthenticator.h in Headers */ = {isa = PBXBuildFile; fileRef = 6FF252A4228A570500663403 /* BasicAuthenticator.h */; };
+		6FF252A7228A570500663403 /* BasicAuthenticator.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 6FF252A5228A570500663403 /* BasicAuthenticator.cpp */; };
 		6FF7478D1B29587D0007F34D /* base64.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 6FF7478B1B29587D0007F34D /* base64.cpp */; };
 		6FF7478E1B29587D0007F34D /* base64.h in Headers */ = {isa = PBXBuildFile; fileRef = 6FF7478C1B29587D0007F34D /* base64.h */; };
 /* End PBXBuildFile section */
@@ -173,6 +182,11 @@
 		6F472B2F1D43B53500D01201 /* TcpConnection.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = TcpConnection.cpp; sourceTree = "<group>"; };
 		6F472B301D43B53500D01201 /* TcpConnection.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TcpConnection.h; sourceTree = "<group>"; };
 		6F4D603C1B9FCA61009132AF /* CoreFoundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreFoundation.framework; path = System/Library/Frameworks/CoreFoundation.framework; sourceTree = SDKROOT; };
+		6F54A1C82273DFC400729E9A /* ProxyConnection.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ProxyConnection.cpp; sourceTree = "<group>"; };
+		6F54A1C92273DFC400729E9A /* ProxyConnection.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ProxyConnection.h; sourceTree = "<group>"; };
+		6F54A2B22275705400729E9A /* ProxyAuthenticator.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ProxyAuthenticator.cpp; sourceTree = "<group>"; };
+		6F54A2B32275705400729E9A /* ProxyAuthenticator.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ProxyAuthenticator.h; sourceTree = "<group>"; };
+		6F54A30022758DC900729E9A /* GSS.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = GSS.framework; path = System/Library/Frameworks/GSS.framework; sourceTree = SDKROOT; };
 		6F5C79E11D59CC8700FF8C83 /* DestroyDetector.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DestroyDetector.h; sourceTree = "<group>"; };
 		6F6208F81A26BDB1000DAF4B /* kmconf.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = kmconf.h; sourceTree = "<group>"; };
 		6F6208FA1A26BDB1000DAF4B /* kmapi.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = kmapi.h; sourceTree = "<group>"; };
@@ -294,6 +308,10 @@
 		6FF211D61B1556FB006603BB /* EventLoopImpl.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = EventLoopImpl.cpp; sourceTree = "<group>"; };
 		6FF211D71B1556FB006603BB /* EventLoopImpl.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = EventLoopImpl.h; sourceTree = "<group>"; };
 		6FF212921B181103006603BB /* kmapi.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = kmapi.cpp; sourceTree = "<group>"; };
+		6FF2529F2289712900663403 /* GssAuthenticator.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GssAuthenticator.h; sourceTree = "<group>"; };
+		6FF252A02289712900663403 /* GssAuthenticator.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = GssAuthenticator.cpp; sourceTree = "<group>"; };
+		6FF252A4228A570500663403 /* BasicAuthenticator.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BasicAuthenticator.h; sourceTree = "<group>"; };
+		6FF252A5228A570500663403 /* BasicAuthenticator.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = BasicAuthenticator.cpp; sourceTree = "<group>"; };
 		6FF7478B1B29587D0007F34D /* base64.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = base64.cpp; sourceTree = "<group>"; };
 		6FF7478C1B29587D0007F34D /* base64.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = base64.h; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -303,6 +321,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				6F54A30122758DC900729E9A /* GSS.framework in Frameworks */,
 				6F4D603D1B9FCA61009132AF /* CoreFoundation.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -323,6 +342,29 @@
 				6FBB2C8F1D139C430024550F /* VPoll.cpp */,
 			);
 			path = poll;
+			sourceTree = "<group>";
+		};
+		6F54A1C72273DF8B00729E9A /* proxy */ = {
+			isa = PBXGroup;
+			children = (
+				6FF252A5228A570500663403 /* BasicAuthenticator.cpp */,
+				6FF252A4228A570500663403 /* BasicAuthenticator.h */,
+				6FF252A02289712900663403 /* GssAuthenticator.cpp */,
+				6FF2529F2289712900663403 /* GssAuthenticator.h */,
+				6F54A2B22275705400729E9A /* ProxyAuthenticator.cpp */,
+				6F54A2B32275705400729E9A /* ProxyAuthenticator.h */,
+				6F54A1C82273DFC400729E9A /* ProxyConnection.cpp */,
+				6F54A1C92273DFC400729E9A /* ProxyConnection.h */,
+			);
+			path = proxy;
+			sourceTree = "<group>";
+		};
+		6F54A2FF22758DC900729E9A /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				6F54A30022758DC900729E9A /* GSS.framework */,
+			);
+			name = Frameworks;
 			sourceTree = "<group>";
 		};
 		6F77ADD62202CCA000BCBB51 /* exts */ = {
@@ -348,6 +390,7 @@
 				6F852E451985EB4700271D87 /* kumaTarget.xcconfig */,
 				6F852DF31985E33000271D87 /* kuma */,
 				6F852DF21985E33000271D87 /* Products */,
+				6F54A2FF22758DC900729E9A /* Frameworks */,
 			);
 			sourceTree = "<group>";
 		};
@@ -362,6 +405,7 @@
 		6F852DF31985E33000271D87 /* kuma */ = {
 			isa = PBXGroup;
 			children = (
+				6F54A1C72273DF8B00729E9A /* proxy */,
 				6FD7C543221964E40005DDFF /* compr */,
 				6FF746A41B201B250007F34D /* http */,
 				6F2963631A18AC4C00C3C79B /* poll */,
@@ -575,6 +619,7 @@
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				6F54A2B52275705400729E9A /* ProxyAuthenticator.h in Headers */,
 				6F6208FB1A26BDB1000DAF4B /* kmconf.h in Headers */,
 				6FD7CBF3223395AC0005DDFF /* WSConnection_v1.h in Headers */,
 				6FE0EF031D409863006136B7 /* H2ConnectionImpl.h in Headers */,
@@ -597,6 +642,7 @@
 				6F9E767A1D36758B005E04B2 /* httpdefs.h in Headers */,
 				6FD7CB9A223232F10005DDFF /* httputils.h in Headers */,
 				6FBB2CB51D139C700024550F /* OpenSslLib.h in Headers */,
+				6FF252A6228A570500663403 /* BasicAuthenticator.h in Headers */,
 				6FF211DA1B1556FB006603BB /* EventLoopImpl.h in Headers */,
 				6F6D14561D9CBDE7008B64E6 /* FlowControl.h in Headers */,
 				6FBB2CAB1D139C560024550F /* HttpRequestImpl.h in Headers */,
@@ -620,6 +666,7 @@
 				6FBB2C911D139C430024550F /* Notifier.h in Headers */,
 				6F2963541A18AB0D00C3C79B /* kmtrace.h in Headers */,
 				6F890534225AEE65004D0DE9 /* H1xStream.h in Headers */,
+				6FF252A12289712900663403 /* GssAuthenticator.h in Headers */,
 				6FE0EF0A1D409863006136B7 /* Http2Request.h in Headers */,
 				6FD3F0F01EC06FE70027D04F /* skbuffer.h in Headers */,
 				6FE0EF0E1D409863006136B7 /* H2Stream.h in Headers */,
@@ -641,6 +688,7 @@
 				6FF211D81B1556FB006603BB /* evdefs.h in Headers */,
 				6FE0EF151D40986D006136B7 /* HPacker.h in Headers */,
 				6F2D40481B194AE200E24928 /* TimerManager.h in Headers */,
+				6F54A1CB2273DFC400729E9A /* ProxyConnection.h in Headers */,
 				6F2732A41EC44A16006E221E /* SocketBase.h in Headers */,
 				6FBB2CAD1D139C560024550F /* HttpResponseImpl.h in Headers */,
 				6FD7C54A221965360005DDFF /* compr.h in Headers */,
@@ -705,6 +753,7 @@
 				6FD7C549221965360005DDFF /* compr.cpp in Sources */,
 				6FD7CBF2223395AC0005DDFF /* WSConnection_v1.cpp in Sources */,
 				6F7512921D76BE27000BE6EC /* Notifier.cpp in Sources */,
+				6FF252A7228A570500663403 /* BasicAuthenticator.cpp in Sources */,
 				6FBB2CB41D139C700024550F /* OpenSslLib.cpp in Sources */,
 				6FBB2CAE1D139C560024550F /* Uri.cpp in Sources */,
 				6FD7C458221293080005DDFF /* crc32.c in Sources */,
@@ -720,6 +769,7 @@
 				6F77AE0522104F1200BCBB51 /* WSExtension.cpp in Sources */,
 				6FBB2CAC1D139C560024550F /* HttpResponseImpl.cpp in Sources */,
 				6FD7CBF5223395AC0005DDFF /* WSConnection_v2.cpp in Sources */,
+				6F54A2B42275705400729E9A /* ProxyAuthenticator.cpp in Sources */,
 				6FD3F0561EBD99790027D04F /* BioHandler.cpp in Sources */,
 				6FE0EF041D409863006136B7 /* H2ConnectionMgr.cpp in Sources */,
 				6F7BBAFE1ED2E4400093BDE3 /* AcceptorBase.cpp in Sources */,
@@ -749,9 +799,11 @@
 				6FBB2CBE1D139C990024550F /* WSHandler.cpp in Sources */,
 				6F2D40471B194AE200E24928 /* TimerManager.cpp in Sources */,
 				6F2733251EC7DF00006E221E /* SslHandler.cpp in Sources */,
+				6FF252A22289712900663403 /* GssAuthenticator.cpp in Sources */,
 				6F6D12EE1D965A9D008B64E6 /* Http1xResponse.cpp in Sources */,
 				6F2963531A18AB0D00C3C79B /* kmtrace.cpp in Sources */,
 				6F8776001EAB4B18002F1165 /* DnsResolver.cpp in Sources */,
+				6F54A1CA2273DFC400729E9A /* ProxyConnection.cpp in Sources */,
 				6F7BBB371ED57B0A0093BDE3 /* UdpSocketBase.cpp in Sources */,
 				6FE0EF071D409863006136B7 /* H2Frame.cpp in Sources */,
 				6FF211D91B1556FB006603BB /* EventLoopImpl.cpp in Sources */,

--- a/src/Makefile
+++ b/src/Makefile
@@ -104,6 +104,9 @@ SRCS =  \
     ssl/BioHandler.cpp \
     ssl/SioHandler.cpp \
     ssl/OpenSslLib.cpp \
+    proxy/ProxyAuthenticator.cpp \
+    proxy/BasicAuthenticator.cpp \
+    proxy/ProxyConnectionImpl.cpp \
     DnsResolver.cpp \
     kmapi.cpp
 

--- a/src/TcpConnection.h
+++ b/src/TcpConnection.h
@@ -39,8 +39,8 @@ public:
     uint32_t getSslFlags() const { return tcp_.getSslFlags(); }
     bool sslEnabled() const { return tcp_.sslEnabled(); }
     virtual KMError connect(const std::string &host, uint16_t port, EventCallback cb);
-    KMError attachFd(SOCKET_FD fd, const KMBuffer *init_buf);
-    KMError attachSocket(TcpSocket::Impl &&tcp, const KMBuffer *init_buf);
+    virtual KMError attachFd(SOCKET_FD fd, const KMBuffer *init_buf);
+    virtual KMError attachSocket(TcpSocket::Impl &&tcp, const KMBuffer *init_buf);
     int send(const void* data, size_t len);
     int send(const iovec* iovs, int count);
     int send(const KMBuffer &buf);
@@ -62,6 +62,7 @@ public:
     KMError setAlpnProtocols(const AlpnProtos &protocols) { return tcp_.setAlpnProtocols(protocols); }
     KMError getAlpnSelected(std::string &protocol) { return tcp_.getAlpnSelected(protocol); }
     KMError setSslServerName(std::string serverName) { return tcp_.setSslServerName(std::move(serverName)); }
+    KMError startSslHandshake(SslRole ssl_role, EventCallback cb) { return tcp_.startSslHandshake(ssl_role, std::move(cb)); }
 #endif
     
     EventLoopPtr eventLoop() { return tcp_.eventLoop(); }

--- a/src/TcpSocketImpl.h
+++ b/src/TcpSocketImpl.h
@@ -69,7 +69,7 @@ public:
     KMError setSslServerName(std::string serverName);
     KMError attachFd(SOCKET_FD fd, SSL *ssl, BIO *nbio);
     KMError detachFd(SOCKET_FD &fd, SSL* &ssl, BIO* &nbio);
-    KMError startSslHandshake(SslRole ssl_role);
+    KMError startSslHandshake(SslRole ssl_role, EventCallback cb=nullptr);
 #endif
     int send(const void* data, size_t length);
     int send(const iovec* iovs, int count);

--- a/src/http/H1xStream.cpp
+++ b/src/http/H1xStream.cpp
@@ -59,6 +59,11 @@ H1xStream::~H1xStream()
     loop_token_.reset();
 }
 
+KMError H1xStream::setProxyInfo(const ProxyInfo &proxy_info)
+{
+    return tcp_conn_.setProxyInfo(proxy_info);
+}
+
 KMError H1xStream::addHeader(std::string name, std::string value)
 {
     return outgoing_message_.addHeader(std::move(name), std::move(value));

--- a/src/http/H1xStream.h
+++ b/src/http/H1xStream.h
@@ -31,6 +31,7 @@
 #include "util/kmobject.h"
 #include "util/DestroyDetector.h"
 #include "util/kmqueue.h"
+#include "proxy/ProxyConnectionImpl.h"
 
 KUMA_NS_BEGIN
 
@@ -50,6 +51,7 @@ public:
     ~H1xStream();
     
     KMError setSslFlags(uint32_t ssl_flags) { return tcp_conn_.setSslFlags(ssl_flags); }
+    KMError setProxyInfo(const ProxyInfo &proxy_info);
     KMError addHeader(std::string name, std::string value);
     KMError sendRequest(const std::string &method, const std::string &url, const std::string &ver);
     KMError attachFd(SOCKET_FD fd, const KMBuffer *init_buf);
@@ -137,7 +139,7 @@ protected:
     CompleteCallback        incoming_complete_cb_;
     CompleteCallback        outgoing_complete_cb_;
     
-    TcpConnection           tcp_conn_;
+    ProxyConnection::Impl   tcp_conn_;
     EventLoopToken          loop_token_;
 };
 

--- a/src/http/Http1xRequest.cpp
+++ b/src/http/Http1xRequest.cpp
@@ -45,7 +45,7 @@ Http1xRequest::Http1xRequest(const EventLoopPtr &loop, std::string ver)
     stream_->setErrorCallback([this] (KMError err) {
         cleanup();
         setState(State::IN_ERROR);
-        if(error_cb_) error_cb_(KMError::FAILED);
+        if(error_cb_) error_cb_(err);
         //onError(err);
     });
     stream_->setIncomingCompleteCallback([this] {

--- a/src/http/Http1xRequest.cpp
+++ b/src/http/Http1xRequest.cpp
@@ -68,6 +68,11 @@ void Http1xRequest::cleanup()
     stream_->close();
 }
 
+KMError Http1xRequest::setProxyInfo(const ProxyInfo &proxy_info)
+{
+    return stream_->setProxyInfo(proxy_info);
+}
+
 KMError Http1xRequest::addHeader(std::string name, std::string value)
 {
     return stream_->addHeader(std::move(name), std::move(value));

--- a/src/http/Http1xRequest.h
+++ b/src/http/Http1xRequest.h
@@ -39,6 +39,7 @@ public:
     ~Http1xRequest();
     
     KMError setSslFlags(uint32_t ssl_flags) override { return stream_->setSslFlags(ssl_flags); }
+    KMError setProxyInfo(const ProxyInfo &proxy_info) override;
     KMError addHeader(std::string name, std::string value) override;
     int sendBody(const void* data, size_t len) override;
     int sendBody(const KMBuffer &buf) override;

--- a/src/http/HttpRequestImpl.h
+++ b/src/http/HttpRequestImpl.h
@@ -29,6 +29,7 @@
 #include "util/kmobject.h"
 #include "HttpParserImpl.h"
 #include "compr/compr.h"
+#include "proxy/proxydefs.h"
 
 #include <map>
 
@@ -48,6 +49,7 @@ public:
     virtual ~Impl() = default;
     
     virtual KMError setSslFlags(uint32_t ssl_flags) = 0;
+    virtual KMError setProxyInfo(const ProxyInfo &proxy_info) = 0;
     virtual KMError addHeader(std::string name, std::string value) = 0;
     virtual KMError addHeader(std::string name, uint32_t value);
     KMError sendRequest(std::string method, std::string url);

--- a/src/http/v2/H2ConnectionImpl.cpp
+++ b/src/http/v2/H2ConnectionImpl.cpp
@@ -91,6 +91,11 @@ void H2Connection::Impl::setConnectionKey(const std::string &key)
     }
 }
 
+KMError H2Connection::Impl::setProxyInfo(const ProxyInfo &proxy_info)
+{
+    return tcp_conn_.setProxyInfo(proxy_info);
+}
+
 KMError H2Connection::Impl::connect(const std::string &host, uint16_t port)
 {
     if(getState() != State::IDLE) {

--- a/src/http/v2/H2ConnectionImpl.h
+++ b/src/http/v2/H2ConnectionImpl.h
@@ -32,6 +32,7 @@
 #include "http/HttpParserImpl.h"
 #include "EventLoopImpl.h"
 #include "util/DestroyDetector.h"
+#include "proxy/ProxyConnectionImpl.h"
 
 #include <map>
 #include <vector>
@@ -55,6 +56,7 @@ public:
     KMError setSslFlags(uint32_t ssl_flags) { return tcp_conn_.setSslFlags(ssl_flags); }
     uint32_t getSslFlags() const { return tcp_conn_.getSslFlags(); }
     bool sslEnabled() const { return tcp_conn_.sslEnabled(); }
+    KMError setProxyInfo(const ProxyInfo &proxy_info);
     KMError connect(const std::string &host, uint16_t port);
     KMError attachFd(SOCKET_FD fd, const KMBuffer *init_buf);
     KMError attachSocket(TcpSocket::Impl&& tcp, HttpParser::Impl&& parser, const KMBuffer *init_buf);
@@ -196,7 +198,7 @@ protected:
     bool expect_continuation_frame_ = false;
     uint32_t stream_id_of_expected_continuation_ = 0;
     
-    TcpConnection tcp_conn_;
+    ProxyConnection::Impl tcp_conn_;
     EventLoopToken loop_token_;
 };
 

--- a/src/http/v2/H2ConnectionMgr.cpp
+++ b/src/http/v2/H2ConnectionMgr.cpp
@@ -49,7 +49,7 @@ H2ConnectionPtr H2ConnectionMgr::getConnection(const std::string &key)
     return it != conn_map_.end() ? it->second : nullptr;
 }
 
-H2ConnectionPtr H2ConnectionMgr::getConnection(const std::string &host, uint16_t port, uint32_t ssl_flags, const EventLoopPtr &loop)
+H2ConnectionPtr H2ConnectionMgr::getConnection(const std::string &host, uint16_t port, uint32_t ssl_flags, const EventLoopPtr &loop, const ProxyInfo &proxy_info)
 {
     std::string key;
     std::string ip;
@@ -68,6 +68,7 @@ H2ConnectionPtr H2ConnectionMgr::getConnection(const std::string &host, uint16_t
     H2ConnectionPtr conn(new H2Connection::Impl(loop));
     conn->setConnectionKey(key);
     conn->setSslFlags(ssl_flags);
+    conn->setProxyInfo(proxy_info);
     if (conn->connect(host, port) != KMError::NOERR) {
         return H2ConnectionPtr();
     }

--- a/src/http/v2/H2ConnectionMgr.h
+++ b/src/http/v2/H2ConnectionMgr.h
@@ -28,6 +28,7 @@
 
 #include "h2defs.h"
 #include "H2ConnectionImpl.h"
+#include "proxy/proxydefs.h"
 
 KUMA_NS_BEGIN
 
@@ -40,7 +41,7 @@ public:
     void addConnection(const std::string &key, H2ConnectionPtr &conn);
     void addConnection(const std::string &key, H2ConnectionPtr &&conn);
     H2ConnectionPtr getConnection(const std::string &key);
-    H2ConnectionPtr getConnection(const std::string &host, uint16_t port, uint32_t ssl_flags, const EventLoopPtr &loop);
+    H2ConnectionPtr getConnection(const std::string &host, uint16_t port, uint32_t ssl_flags, const EventLoopPtr &loop, const ProxyInfo &proxy_info);
     void removeConnection(const std::string key);
     
 public:

--- a/src/http/v2/H2StreamProxy.cpp
+++ b/src/http/v2/H2StreamProxy.cpp
@@ -49,6 +49,13 @@ H2StreamProxy::~H2StreamProxy()
     loop_token_.reset();
 }
 
+KMError H2StreamProxy::setProxyInfo(const ProxyInfo &proxy_info)
+{
+    proxy_info_ = proxy_info;
+    
+    return KMError::NOERR;
+}
+
 KMError H2StreamProxy::addHeader(std::string name, std::string value)
 {
     if (name == H2HeaderProtocol) {
@@ -86,7 +93,7 @@ KMError H2StreamProxy::sendRequest(std::string method, std::string url, uint32_t
     }
     
     auto &conn_mgr = H2ConnectionMgr::getRequestConnMgr(ssl_flags != SSL_NONE);
-    conn_ = conn_mgr.getConnection(uri_.getHost(), port, ssl_flags, loop);
+    conn_ = conn_mgr.getConnection(uri_.getHost(), port, ssl_flags, loop, proxy_info_);
     if (!conn_ || !conn_->eventLoop()) {
         KUMA_ERRXTRACE("sendRequest, failed to get H2Connection");
         return KMError::INVALID_PARAM;

--- a/src/http/v2/H2StreamProxy.h
+++ b/src/http/v2/H2StreamProxy.h
@@ -28,6 +28,7 @@
 #include "util/kmobject.h"
 #include "util/DestroyDetector.h"
 #include "util/kmqueue.h"
+#include "proxy/proxydefs.h"
 
 KUMA_NS_BEGIN
 
@@ -43,6 +44,7 @@ public:
     H2StreamProxy(const EventLoopPtr &loop);
     ~H2StreamProxy();
     
+    KMError setProxyInfo(const ProxyInfo &proxy_info);
     KMError addHeader(std::string name, std::string value);
     KMError sendRequest(std::string method, std::string url, uint32_t ssl_flags);
     KMError attachStream(uint32_t stream_id, H2Connection::Impl* conn);
@@ -190,6 +192,7 @@ protected:
     Uri uri_;
     std::string protocol_;
     HttpHeader outgoing_header_{true, true};
+    ProxyInfo proxy_info_;
     
     // incoming
     HttpHeader incoming_header_{false, true};

--- a/src/http/v2/Http2Request.cpp
+++ b/src/http/v2/Http2Request.cpp
@@ -64,6 +64,11 @@ KMError Http2Request::setSslFlags(uint32_t ssl_flags)
     return KMError::NOERR;
 }
 
+KMError Http2Request::setProxyInfo(const ProxyInfo &proxy_info)
+{
+    return stream_->setProxyInfo(proxy_info);
+}
+
 KMError Http2Request::addHeader(std::string name, std::string value)
 {
     return stream_->addHeader(std::move(name), std::move(value));

--- a/src/http/v2/Http2Request.h
+++ b/src/http/v2/Http2Request.h
@@ -50,6 +50,7 @@ public:
     ~Http2Request();
     
     KMError setSslFlags(uint32_t ssl_flags) override;
+    KMError setProxyInfo(const ProxyInfo &proxy_info) override;
     KMError addHeader(std::string name, std::string value) override;
     int sendBody(const void* data, size_t len) override;
     int sendBody(const KMBuffer &buf) override;

--- a/src/jni/Android.mk
+++ b/src/jni/Android.mk
@@ -85,6 +85,9 @@ LOCAL_SRC_FILES := \
     ssl/BioHandler.cpp \
     ssl/SioHandler.cpp \
     ssl/OpenSslLib.cpp \
+    proxy/ProxyAuthenticator.cpp \
+    proxy/BasicAuthenticator.cpp \
+    proxy/ProxyConnectionImpl.cpp \
     DnsResolver.cpp \
     kmapi.cpp
 

--- a/src/kmdefs.h
+++ b/src/kmdefs.h
@@ -64,6 +64,7 @@ enum class KMError : int {
     BUFFER_TOO_SMALL    = -16,
     NOT_SUPPORTED       = -17,
     NOT_IMPLEMENTED     = -18,
+    NOT_AUTHORIZED      = -19,
     
     DESTROYED           = -699
 };

--- a/src/proxy/BasicAuthenticator.cpp
+++ b/src/proxy/BasicAuthenticator.cpp
@@ -1,0 +1,70 @@
+/* Copyright (c) 2014-2019, Fengping Bao <jamol@live.com>
+*
+* Permission is hereby granted, free of charge, to any person obtaining a copy
+* of this software and associated documentation files (the "Software"), to deal
+* in the Software without restriction, including without limitation the rights
+* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+* copies of the Software, and to permit persons to whom the Software is
+* furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included in all
+* copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+* WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+* MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+* ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+* WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+* ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+* OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+*/
+
+#include "BasicAuthenticator.h"
+#include "util/kmtrace.h"
+#include "util/base64.h"
+
+
+using namespace kuma;
+
+BasicAuthenticator::BasicAuthenticator()
+{
+    
+}
+
+BasicAuthenticator::~BasicAuthenticator()
+{
+    
+}
+
+bool BasicAuthenticator::init(const std::string &user, const std::string &passwd)
+{
+    if (!user.empty()) {
+        std::string str = user + ":" + passwd;
+        auth_token_ = x64_encode(str, false);
+    }
+    return true;
+}
+
+bool BasicAuthenticator::nextAuthToken(const std::string& challenge)
+{
+    if (!hasAuthHeader())
+    {
+        return false;
+    }
+    
+    return true;
+}
+
+std::string BasicAuthenticator::getAuthHeader() const
+{
+    if (hasAuthHeader()) {
+        return "Basic " + auth_token_;
+    }
+    
+    return "";
+}
+
+bool BasicAuthenticator::hasAuthHeader() const
+{
+    return !auth_token_.empty();
+}

--- a/src/proxy/BasicAuthenticator.h
+++ b/src/proxy/BasicAuthenticator.h
@@ -1,0 +1,47 @@
+/* Copyright (c) 2014-2019, Fengping Bao <jamol@live.com>
+*
+* Permission is hereby granted, free of charge, to any person obtaining a copy
+* of this software and associated documentation files (the "Software"), to deal
+* in the Software without restriction, including without limitation the rights
+* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+* copies of the Software, and to permit persons to whom the Software is
+* furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included in all
+* copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+* WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+* MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+* ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+* WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+* ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+* OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+*/
+
+#pragma once
+
+#include "kmdefs.h"
+#include "ProxyAuthenticator.h"
+
+#include <string>
+
+
+KUMA_NS_BEGIN
+
+class BasicAuthenticator : public ProxyAuthenticator
+{
+public:
+    BasicAuthenticator();
+    virtual ~BasicAuthenticator();
+
+    bool init(const std::string &user, const std::string &passwd);
+    bool nextAuthToken(const std::string& challenge) override;
+    std::string getAuthHeader() const override;
+    bool hasAuthHeader() const override;
+
+protected:
+    std::string     auth_token_;
+};
+
+KUMA_NS_END

--- a/src/proxy/BasicAuthenticator.h
+++ b/src/proxy/BasicAuthenticator.h
@@ -33,7 +33,7 @@ class BasicAuthenticator : public ProxyAuthenticator
 {
 public:
     BasicAuthenticator();
-    virtual ~BasicAuthenticator();
+    ~BasicAuthenticator();
 
     bool init(const std::string &user, const std::string &passwd);
     bool nextAuthToken(const std::string& challenge) override;

--- a/src/proxy/GssAuthenticator.cpp
+++ b/src/proxy/GssAuthenticator.cpp
@@ -1,0 +1,229 @@
+/* Copyright (c) 2014-2019, Fengping Bao <jamol@live.com>
+*
+* Permission is hereby granted, free of charge, to any person obtaining a copy
+* of this software and associated documentation files (the "Software"), to deal
+* in the Software without restriction, including without limitation the rights
+* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+* copies of the Software, and to permit persons to whom the Software is
+* furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included in all
+* copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+* WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+* MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+* ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+* WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+* ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+* OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+*/
+
+#include "GssAuthenticator.h"
+#include "util/util.h"
+#include "util/kmtrace.h"
+#include "util/base64.h"
+
+
+using namespace kuma;
+
+GssAuthenticator::GssAuthenticator()
+{
+    KM_SetObjKey("GssAuthenticator");
+}
+
+GssAuthenticator::~GssAuthenticator()
+{
+    if(cred_id_ != GSS_C_NO_CREDENTIAL)
+    {
+        gss_release_cred(&minor_status_, &cred_id_);
+    }
+    
+    if(gss_domain_name_ != GSS_C_NO_NAME)
+    {
+        gss_release_name(&minor_status_, &gss_domain_name_);
+    }
+    
+    if(gss_user_name_ != GSS_C_NO_NAME)
+    {
+        gss_release_name(&minor_status_, &gss_user_name_);
+    }
+    
+    if(ctx_id_ != GSS_C_NO_CONTEXT)
+    {
+        gss_delete_sec_context(&minor_status_, &ctx_id_, GSS_C_NO_BUFFER);
+    }
+}
+
+bool GssAuthenticator::init(const std::string& proxy_name, const std::string& auth_scheme, const std::string &domain_user, const std::string &password)
+{
+    proxy_name_ = proxy_name;
+    auth_scheme_ = auth_scheme;
+    
+    if(is_equal(auth_scheme, "Negotiate"))
+    {
+        mech_oid_ = GSS_SPNEGO_MECHANISM;
+    }
+    else if(is_equal(auth_scheme, "NTLM"))
+    {
+        mech_oid_ = GSS_NTLM_MECHANISM;
+    }
+    else
+    {
+        mech_oid_ = gss_OID();
+    }
+
+    std::string domain_name;
+    std::string user_name;
+    const auto back_slash_pos = domain_user.find_first_of("\\");
+    if(back_slash_pos != std::string::npos)
+    {
+        domain_name = domain_user.substr(0, back_slash_pos);
+        user_name = domain_user.substr(back_slash_pos + 1);
+    }
+    else
+    {
+        user_name = domain_user;
+    }
+    
+    gss_buffer_desc domain_name_token;
+    domain_name_token.value = (void*)domain_name.c_str();
+    domain_name_token.length = domain_name.length();
+    
+    major_status_ = gss_import_name(&minor_status_,
+                                 &domain_name_token,
+                                 GSS_C_NT_HOSTBASED_SERVICE,
+                                 &gss_domain_name_);
+    
+    if(GSS_ERROR(major_status_))
+    {
+        return false;
+    }
+    
+    if(!domain_user.empty())
+    {
+        gss_buffer_desc user_name_token;
+        user_name_token.value = (void*)user_name.c_str();
+        user_name_token.length = user_name.length();
+        
+        major_status_ = gss_import_name(&minor_status_,
+                                     &user_name_token,
+                                     GSS_C_NT_USER_NAME,
+                                     &gss_user_name_);
+        
+        if(GSS_ERROR(major_status_))
+        {
+            return false;
+        }
+        
+        gss_buffer_desc password_token;
+        password_token.value = (void*)password.c_str();
+        password_token.length = password.length();
+        
+        // Binary representation of NTLM OID (https://msdn.microsoft.com/en-us/library/cc236636.aspx)
+        static char gss_ntlm_oid_value[] = "\x2b\x06\x01\x04\x01\x82\x37\x02\x02\x0a";
+        static gss_OID_desc gss_mech_ntlm_OID_desc = {
+            .length = ARRAY_SIZE(gss_ntlm_oid_value) - 1,
+            .elements = static_cast<void*>(gss_ntlm_oid_value)
+        };
+        
+        gss_OID_desc gss_mech_OID_desc;
+        
+        gss_mech_OID_desc = gss_mech_ntlm_OID_desc;
+        
+        gss_OID_set_desc gss_mech_OID_set_desc = {
+            .count = 1,
+            .elements = &gss_mech_OID_desc
+        };
+        gss_OID_set desiredMech = &gss_mech_OID_set_desc;
+        
+        major_status_ = gss_acquire_cred_with_password(&minor_status_,
+                                                    gss_user_name_,
+                                                    &password_token,
+                                                    GSS_C_INDEFINITE,
+                                                    desiredMech,
+                                                    GSS_C_INITIATE,
+                                                    &cred_id_,
+                                                    nullptr,
+                                                    nullptr);
+        
+        if(GSS_ERROR(major_status_))
+        {
+            return false;
+        }
+    }
+
+    return true;
+}
+
+bool GssAuthenticator::nextAuthToken(const std::string& challenge)
+{
+    auth_token_ = "";
+    if (!hasAuthHeader())
+    {
+        return false;
+    }
+    
+    gss_buffer_desc input_token_obj, output_token_obj;
+    gss_buffer_t input_token = &input_token_obj, output_token = &output_token_obj;
+    
+    const auto decoded_challenge = x64_decode(challenge);
+    
+    if(!challenge.empty())
+    {
+        input_token->value = (void*)decoded_challenge.data();
+        input_token->length = decoded_challenge.size();
+    }
+    else
+    {
+        input_token->length = 0;
+    }
+    
+    major_status_ = gss_init_sec_context(&minor_status_,
+                                      cred_id_,
+                                      &ctx_id_,
+                                      gss_domain_name_,
+                                      mech_oid_,
+                                      GSS_C_MUTUAL_FLAG | GSS_C_SEQUENCE_FLAG,
+                                      0,
+                                      nullptr,
+                                      input_token,
+                                      nullptr,
+                                      output_token,
+                                      nullptr,
+                                      nullptr);
+    
+    
+    if(GSS_ERROR(major_status_))
+    {
+        return false;
+    }
+    
+    if(output_token->length != 0)
+    {
+        auth_token_ = x64_encode(output_token->value, output_token->length, false);
+        
+        gss_release_buffer(&minor_status_, output_token);
+    }
+    
+    return true;
+}
+
+std::string GssAuthenticator::getAuthHeader() const
+{
+    if (hasAuthHeader()) {
+        return auth_scheme_ + " " + auth_token_;
+    }
+    
+    return "";
+}
+
+bool GssAuthenticator::hasAuthHeader() const
+{
+    const bool hasCreds = gss_user_name_ != GSS_C_NO_NAME;
+    const bool errorHappened = GSS_ERROR(major_status_);
+    const bool isInitialState = (major_status_ == 0);
+    const bool needsContinue = (major_status_ & GSS_S_CONTINUE_NEEDED);
+    
+    return hasCreds && !errorHappened && (isInitialState || needsContinue);
+}

--- a/src/proxy/GssAuthenticator.h
+++ b/src/proxy/GssAuthenticator.h
@@ -1,0 +1,62 @@
+/* Copyright (c) 2014-2019, Fengping Bao <jamol@live.com>
+*
+* Permission is hereby granted, free of charge, to any person obtaining a copy
+* of this software and associated documentation files (the "Software"), to deal
+* in the Software without restriction, including without limitation the rights
+* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+* copies of the Software, and to permit persons to whom the Software is
+* furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included in all
+* copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+* WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+* MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+* ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+* WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+* ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+* OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+*/
+
+#pragma once
+
+#include "kmdefs.h"
+#include "ProxyAuthenticator.h"
+#include "util/kmobject.h"
+
+#include <string>
+
+#include <GSS/gssapi.h>
+#include <GSS/gssapi_krb5.h>
+#include <GSS/gssapi_spnego.h>
+
+
+KUMA_NS_BEGIN
+
+class GssAuthenticator : public KMObject, public ProxyAuthenticator
+{
+public:
+    GssAuthenticator();
+    virtual ~GssAuthenticator();
+
+    bool init(const std::string &proxy_name, const std::string &auth_scheme, const std::string &domain_user, const std::string &passwd);
+    bool nextAuthToken(const std::string& challenge) override;
+    std::string getAuthHeader() const override;
+    bool hasAuthHeader() const override;
+
+protected:
+    std::string     proxy_name_;
+    std::string     auth_scheme_;
+    std::string     auth_token_;
+    
+    gss_ctx_id_t    ctx_id_ = GSS_C_NO_CONTEXT;
+    gss_cred_id_t   cred_id_ = GSS_C_NO_CREDENTIAL;
+    OM_uint32       major_status_ = 0;
+    OM_uint32       minor_status_ = 0;
+    gss_OID         mech_oid_ = GSS_C_NO_OID;
+    gss_name_t      gss_domain_name_ = GSS_C_NO_NAME;
+    gss_name_t      gss_user_name_ = GSS_C_NO_NAME;
+};
+
+KUMA_NS_END

--- a/src/proxy/GssapiAuthenticator.cpp
+++ b/src/proxy/GssapiAuthenticator.cpp
@@ -27,6 +27,8 @@
 
 using namespace kuma;
 
+static std::string getSecurityStatusString(OM_uint32 major_status);
+
 GssapiAuthenticator::GssapiAuthenticator()
 {
     KM_SetObjKey("GssapiAuthenticator");
@@ -39,9 +41,9 @@ GssapiAuthenticator::~GssapiAuthenticator()
         gss_release_cred(&minor_status_, &cred_id_);
     }
     
-    if(gss_domain_name_ != GSS_C_NO_NAME)
+    if(gss_spn_name_ != GSS_C_NO_NAME)
     {
-        gss_release_name(&minor_status_, &gss_domain_name_);
+        gss_release_name(&minor_status_, &gss_spn_name_);
     }
     
     if(gss_user_name_ != GSS_C_NO_NAME)
@@ -59,88 +61,113 @@ bool GssapiAuthenticator::init(const AuthInfo &auth_info, const RequestInfo &req
 {
     auth_scheme_ = auth_info.scheme;
     
-    if(auth_scheme_ == AuthScheme::NEGOTIATE)
+#ifdef GSS_NTLM_MECHANISM
+    static gss_OID gss_mech_ntlm_OID = GSS_NTLM_MECHANISM;
+#else
+    static gss_OID_desc gss_mech_ntlm_OID_desc = {
+        10,
+        const_cast<char*>("\x2b\x06\x01\x04\x01\x82\x37\x02\x02\x0a")
+    };
+    static gss_OID gss_mech_ntlm_OID = &gss_mech_ntlm_OID_desc;
+#endif
+    
+#ifdef GSS_SPNEGO_MECHANISM
+    static gss_OID gss_mech_spnego_OID = GSS_SPNEGO_MECHANISM;
+#else
+    static gss_OID_desc gss_mech_spnego_OID_desc = {
+        6,
+        const_cast<char*>("\x2b\x06\x01\x05\x05\x02")
+    };
+    static gss_OID gss_mech_spnego_OID = &gss_mech_spnego_OID_desc;
+#endif
+    
+#ifdef GSS_KRB5_MECHANISM
+    static gss_OID gss_mech_krb5_OID = GSS_KRB5_MECHANISM;
+#else
+    static gss_OID_desc gss_mech_krb5_OID_desc = {
+        9,
+        const_cast<char*>("\x2a\x86\x48\x86\xf7\x12\x01\x02\x02")
+    };
+    static gss_OID gss_mech_krb5_OID = &gss_mech_krb5_OID_desc;
+#endif
+    
+    if(auth_scheme_ == AuthScheme::NTLM)
     {
-        mech_oid_ = GSS_SPNEGO_MECHANISM;
-    }
-    else if(auth_scheme_ == AuthScheme::NTLM)
-    {
-        mech_oid_ = GSS_NTLM_MECHANISM;
+        mech_oid_ = gss_mech_ntlm_OID;
     }
     else
     {
-        mech_oid_ = gss_OID();
-    }
-
-    std::string domain_name;
-    std::string user_name;
-    const auto back_slash_pos = auth_info.user.find_first_of("\\");
-    if(back_slash_pos != std::string::npos)
-    {
-        domain_name = auth_info.user.substr(0, back_slash_pos);
-        user_name = auth_info.user.substr(back_slash_pos + 1);
-    }
-    else
-    {
-        user_name = auth_info.user;
+        mech_oid_ = gss_mech_spnego_OID;
     }
     
-    gss_buffer_desc domain_name_token;
-    domain_name_token.value = (void*)domain_name.c_str();
-    domain_name_token.length = domain_name.length();
+    std::string spn;
+    if (!req_info.service.empty()) {
+        spn = req_info.service + "/" + req_info.host;
+    } else {
+        spn = "HTTP/" + req_info.host;
+    }
     
+    gss_buffer_desc spn_buffer = GSS_C_EMPTY_BUFFER;
+    spn_buffer.value = const_cast<char*>(spn.c_str());
+    spn_buffer.length = spn.size() + 1;
     major_status_ = gss_import_name(&minor_status_,
-                                 &domain_name_token,
-                                 GSS_C_NT_HOSTBASED_SERVICE,
-                                 &gss_domain_name_);
-    
+                                    &spn_buffer,
+                                    GSS_C_NT_HOSTBASED_SERVICE,
+                                    &gss_spn_name_);
     if(GSS_ERROR(major_status_))
     {
+        KUMA_ERRXTRACE("init, SPN gss_import_name failed, err=" << getSecurityStatusString(major_status_));
         return false;
     }
     
     if(!auth_info.user.empty())
     {
-        gss_buffer_desc user_name_token;
-        user_name_token.value = (void*)user_name.c_str();
-        user_name_token.length = user_name.length();
+        std::string domain_name;
+        std::string user_name;
+        const auto back_slash_pos = auth_info.user.find_first_of("\\");
+        if(back_slash_pos != std::string::npos)
+        {
+            domain_name = auth_info.user.substr(0, back_slash_pos);
+            user_name = auth_info.user.substr(back_slash_pos + 1);
+        }
+        else
+        {
+            user_name = auth_info.user;
+        }
+        
+        gss_buffer_desc user_buffer;
+        user_buffer.value = (void*)user_name.c_str();
+        user_buffer.length = user_name.length();
         
         major_status_ = gss_import_name(&minor_status_,
-                                     &user_name_token,
+                                     &user_buffer,
                                      GSS_C_NT_USER_NAME,
                                      &gss_user_name_);
         
         if(GSS_ERROR(major_status_))
         {
+            KUMA_ERRXTRACE("init, username gss_import_name failed, err=" << getSecurityStatusString(major_status_));
             return false;
         }
         
-        gss_buffer_desc password_token;
-        password_token.value = (void*)auth_info.passwd.c_str();
-        password_token.length = auth_info.passwd.length();
+        gss_buffer_desc passwd_buffer;
+        passwd_buffer.value = (void*)auth_info.passwd.c_str();
+        passwd_buffer.length = auth_info.passwd.length();
         
-        // Binary representation of NTLM OID (https://msdn.microsoft.com/en-us/library/cc236636.aspx)
-        static char gss_ntlm_oid_value[] = "\x2b\x06\x01\x04\x01\x82\x37\x02\x02\x0a";
-        static gss_OID_desc gss_mech_ntlm_OID_desc = {
-            .length = ARRAY_SIZE(gss_ntlm_oid_value) - 1,
-            .elements = static_cast<void*>(gss_ntlm_oid_value)
-        };
-        
-        gss_OID_desc gss_mech_OID_desc;
-        
-        gss_mech_OID_desc = gss_mech_ntlm_OID_desc;
-        
+        gss_OID_set desired_mech = GSS_C_NO_OID_SET;//&gss_mech_OID_set_desc;
+#ifndef GSS_SPNEGO_MECHANISM
         gss_OID_set_desc gss_mech_OID_set_desc = {
             .count = 1,
-            .elements = &gss_mech_OID_desc
+            .elements = mech_oid_
         };
-        gss_OID_set desiredMech = &gss_mech_OID_set_desc;
+        desired_mech = &gss_mech_OID_set_desc;
+#endif
         
         major_status_ = gss_acquire_cred_with_password(&minor_status_,
                                                     gss_user_name_,
-                                                    &password_token,
+                                                    &passwd_buffer,
                                                     GSS_C_INDEFINITE,
-                                                    desiredMech,
+                                                    desired_mech,
                                                     GSS_C_INITIATE,
                                                     &cred_id_,
                                                     nullptr,
@@ -148,6 +175,7 @@ bool GssapiAuthenticator::init(const AuthInfo &auth_info, const RequestInfo &req
         
         if(GSS_ERROR(major_status_))
         {
+            KUMA_ERRXTRACE("init, gss_acquire_cred_with_password failed, err=" << getSecurityStatusString(major_status_));
             return false;
         }
     }
@@ -163,38 +191,36 @@ bool GssapiAuthenticator::nextAuthToken(const std::string& challenge)
         return false;
     }
     
-    gss_buffer_desc input_token_obj, output_token_obj;
-    gss_buffer_t input_token = &input_token_obj, output_token = &output_token_obj;
+    gss_buffer_desc input_token_obj = GSS_C_EMPTY_BUFFER;
+    gss_buffer_desc output_token_obj = GSS_C_EMPTY_BUFFER;
+    gss_buffer_t input_token = &input_token_obj;
+    gss_buffer_t output_token = &output_token_obj;
     
-    const auto decoded_challenge = x64_decode(challenge);
-    
+    std::string decoded_challenge;
     if(!challenge.empty())
     {
+        decoded_challenge = x64_decode(challenge);
         input_token->value = (void*)decoded_challenge.data();
         input_token->length = decoded_challenge.size();
-    }
-    else
-    {
-        input_token->length = 0;
     }
     
     major_status_ = gss_init_sec_context(&minor_status_,
                                       cred_id_,
                                       &ctx_id_,
-                                      gss_domain_name_,
+                                      gss_spn_name_,
                                       mech_oid_,
                                       GSS_C_MUTUAL_FLAG | GSS_C_SEQUENCE_FLAG,
-                                      0,
-                                      nullptr,
+                                      GSS_C_INDEFINITE,
+                                      GSS_C_NO_CHANNEL_BINDINGS,
                                       input_token,
                                       nullptr,
                                       output_token,
                                       nullptr,
                                       nullptr);
     
-    
     if(GSS_ERROR(major_status_))
     {
+        KUMA_ERRXTRACE("init, gss_init_sec_context failed, err=" << getSecurityStatusString(major_status_));
         return false;
     }
     
@@ -225,4 +251,43 @@ bool GssapiAuthenticator::hasAuthHeader() const
     const bool needsContinue = (major_status_ & GSS_S_CONTINUE_NEEDED);
     
     return hasCreds && !errorHappened && (isInitialState || needsContinue);
+}
+
+static std::string getSecurityStatusString(OM_uint32 major_status)
+{
+    OM_uint32 routine_status = GSS_ROUTINE_ERROR(major_status);
+    OM_uint32 calling_status = GSS_CALLING_ERROR(major_status);
+    OM_uint32 supplemental_status = GSS_SUPPLEMENTARY_INFO(major_status);
+    switch (routine_status) {
+        case GSS_S_FAILURE:
+            return "GSS_S_FAILURE";
+        case GSS_S_DEFECTIVE_TOKEN:
+            return "GSS_S_DEFECTIVE_TOKEN";
+        case GSS_S_DEFECTIVE_CREDENTIAL:
+            return "GSS_S_DEFECTIVE_CREDENTIAL";
+        case GSS_S_BAD_SIG:
+            return "GSS_S_BAD_SIG";
+        case GSS_S_NO_CRED:
+            return "GSS_S_NO_CRED";
+        case GSS_S_CREDENTIALS_EXPIRED:
+            return "GSS_S_CREDENTIALS_EXPIRED";
+        case GSS_S_BAD_BINDINGS:
+            return "GSS_S_BAD_BINDINGS";
+        case GSS_S_NO_CONTEXT:
+            return "GSS_S_NO_CONTEXT";
+        case GSS_S_BAD_NAMETYPE:
+            return "GSS_S_BAD_NAMETYPE";
+        case GSS_S_BAD_NAME:
+            return "GSS_S_BAD_NAME";
+        case GSS_S_BAD_MECH:
+            return "GSS_S_BAD_MECH";
+        default:
+            if (routine_status != 0) {
+                return std::to_string(routine_status) + " " +
+                       std::to_string(calling_status) + " " +
+                       std::to_string(supplemental_status);
+            }
+    }
+    
+    return "NOERR";
 }

--- a/src/proxy/GssapiAuthenticator.h
+++ b/src/proxy/GssapiAuthenticator.h
@@ -19,52 +19,43 @@
 * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 */
 
-#include "BasicAuthenticator.h"
-#include "util/kmtrace.h"
-#include "util/base64.h"
+#pragma once
+
+#include "kmdefs.h"
+#include "ProxyAuthenticator.h"
+#include "util/kmobject.h"
+
+#include <string>
+
+#include <GSS/gssapi.h>
+#include <GSS/gssapi_krb5.h>
+#include <GSS/gssapi_spnego.h>
 
 
-using namespace kuma;
+KUMA_NS_BEGIN
 
-BasicAuthenticator::BasicAuthenticator()
+class GssapiAuthenticator : public KMObject, public ProxyAuthenticator
 {
+public:
+    GssapiAuthenticator();
+    ~GssapiAuthenticator();
+
+    bool init(const AuthInfo &auth_info, const RequestInfo &req_info);
+    bool nextAuthToken(const std::string& challenge) override;
+    std::string getAuthHeader() const override;
+    bool hasAuthHeader() const override;
+
+protected:
+    AuthScheme      auth_scheme_;
+    std::string     auth_token_;
     
-}
+    gss_ctx_id_t    ctx_id_ = GSS_C_NO_CONTEXT;
+    gss_cred_id_t   cred_id_ = GSS_C_NO_CREDENTIAL;
+    OM_uint32       major_status_ = 0;
+    OM_uint32       minor_status_ = 0;
+    gss_OID         mech_oid_ = GSS_C_NO_OID;
+    gss_name_t      gss_domain_name_ = GSS_C_NO_NAME;
+    gss_name_t      gss_user_name_ = GSS_C_NO_NAME;
+};
 
-BasicAuthenticator::~BasicAuthenticator()
-{
-    
-}
-
-bool BasicAuthenticator::init(const std::string &user, const std::string &passwd)
-{
-    if (!user.empty()) {
-        std::string str = user + ":" + passwd;
-        auth_token_ = x64_encode(str, false);
-    }
-    return true;
-}
-
-bool BasicAuthenticator::nextAuthToken(const std::string& challenge)
-{
-    if (!hasAuthHeader())
-    {
-        return false;
-    }
-    
-    return true;
-}
-
-std::string BasicAuthenticator::getAuthHeader() const
-{
-    if (hasAuthHeader()) {
-        return "BASIC " + auth_token_;
-    }
-    
-    return "";
-}
-
-bool BasicAuthenticator::hasAuthHeader() const
-{
-    return !auth_token_.empty();
-}
+KUMA_NS_END

--- a/src/proxy/GssapiAuthenticator.h
+++ b/src/proxy/GssapiAuthenticator.h
@@ -54,7 +54,7 @@ protected:
     OM_uint32       major_status_ = 0;
     OM_uint32       minor_status_ = 0;
     gss_OID         mech_oid_ = GSS_C_NO_OID;
-    gss_name_t      gss_domain_name_ = GSS_C_NO_NAME;
+    gss_name_t      gss_spn_name_ = GSS_C_NO_NAME;
     gss_name_t      gss_user_name_ = GSS_C_NO_NAME;
 };
 

--- a/src/proxy/ProxyAuthenticator.cpp
+++ b/src/proxy/ProxyAuthenticator.cpp
@@ -1,0 +1,82 @@
+/* Copyright (c) 2014-2019, Fengping Bao <jamol@live.com>
+*
+* Permission is hereby granted, free of charge, to any person obtaining a copy
+* of this software and associated documentation files (the "Software"), to deal
+* in the Software without restriction, including without limitation the rights
+* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+* copies of the Software, and to permit persons to whom the Software is
+* furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included in all
+* copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+* WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+* MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+* ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+* WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+* ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+* OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+*/
+
+#include "ProxyAuthenticator.h"
+#include "util/util.h"
+#include "util/kmtrace.h"
+
+#if defined(KUMA_OS_WIN)
+# include <windows.h>
+# include "SspiAuthenticator.h"
+#elif defined(KUMA_OS_MAC)
+# include "GssAuthenticator.h"
+#elif defined(KUMA_OS_LINUX)
+
+#else
+# error "UNSUPPORTED OS"
+#endif
+
+#include "BasicAuthenticator.h"
+
+using namespace kuma;
+
+ProxyAuthenticator::ProxyAuthenticator()
+{
+    
+}
+
+ProxyAuthenticator::~ProxyAuthenticator()
+{
+    
+}
+
+ProxyAuthenticator::Ptr ProxyAuthenticator::create(const std::string scheme,
+                                                   const std::string &domain_user,
+                                                   const std::string &passwd)
+{
+    if (is_equal(scheme, "Basic")) {
+        auto *basic = new BasicAuthenticator();
+        auto ptr =  Ptr(basic);
+        if (!basic->init(domain_user, passwd)) {
+            ptr.reset();
+        }
+        return ptr;
+    } else if (is_equal(scheme, "NTLM") || is_equal(scheme, "Negotiate")) {
+#if defined(KUMA_OS_WIN)
+        auto *sspi = new SspiAuthenticator();
+        auto ptr =  Ptr(sspi);
+        if (!sspi->init("", scheme, domain_user, passwd)) {
+            ptr.reset();
+        }
+        return ptr;
+#elif defined(KUMA_OS_MAC)
+        auto *gss = new GssAuthenticator();
+        auto ptr =  Ptr(gss);
+        if (!gss->init("", scheme, domain_user, passwd)) {
+            ptr.reset();
+        }
+        return ptr;
+#else
+#endif
+    }
+    
+    return Ptr();
+}

--- a/src/proxy/ProxyAuthenticator.h
+++ b/src/proxy/ProxyAuthenticator.h
@@ -28,19 +28,45 @@
 
 KUMA_NS_BEGIN
 
+
 class ProxyAuthenticator
 {
 public:
     using Ptr = std::unique_ptr<ProxyAuthenticator>;
-    
+    enum class AuthScheme
+    {
+        UNKNOWN,
+        BASIC,
+        NTLM,
+        DIGEST,
+        NEGOTIATE
+    };
+    struct AuthInfo
+    {
+        AuthScheme scheme;
+        std::string user;
+        std::string passwd;
+    };
+    struct RequestInfo
+    {
+        std::string host;
+        uint16_t port;
+        std::string method;
+        std::string path;
+        std::string service;
+    };
+
     ProxyAuthenticator();
     virtual ~ProxyAuthenticator();
     
     virtual bool nextAuthToken(const std::string& challenge) = 0;
     virtual std::string getAuthHeader() const = 0;
     virtual bool hasAuthHeader() const = 0;
+
+    static AuthScheme getAuthScheme(const std::string &scheme);
+    static std::string getAuthScheme(AuthScheme scheme);
     
-    static Ptr create(const std::string scheme, const std::string &domain_user, const std::string &passwd);
+    static Ptr create(const AuthInfo &auth_info, const RequestInfo &req_info);
 };
 
 KUMA_NS_END

--- a/src/proxy/ProxyAuthenticator.h
+++ b/src/proxy/ProxyAuthenticator.h
@@ -1,0 +1,46 @@
+/* Copyright (c) 2014-2019, Fengping Bao <jamol@live.com>
+*
+* Permission is hereby granted, free of charge, to any person obtaining a copy
+* of this software and associated documentation files (the "Software"), to deal
+* in the Software without restriction, including without limitation the rights
+* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+* copies of the Software, and to permit persons to whom the Software is
+* furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included in all
+* copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+* WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+* MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+* ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+* WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+* ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+* OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+*/
+
+#pragma once
+
+#include "kmdefs.h"
+
+#include <string>
+#include <memory>
+
+KUMA_NS_BEGIN
+
+class ProxyAuthenticator
+{
+public:
+    using Ptr = std::unique_ptr<ProxyAuthenticator>;
+    
+    ProxyAuthenticator();
+    virtual ~ProxyAuthenticator();
+    
+    virtual bool nextAuthToken(const std::string& challenge) = 0;
+    virtual std::string getAuthHeader() const = 0;
+    virtual bool hasAuthHeader() const = 0;
+    
+    static Ptr create(const std::string scheme, const std::string &domain_user, const std::string &passwd);
+};
+
+KUMA_NS_END

--- a/src/proxy/ProxyConnection.cpp
+++ b/src/proxy/ProxyConnection.cpp
@@ -1,0 +1,259 @@
+/* Copyright (c) 2014-2019, Fengping Bao <jamol@live.com>
+*
+* Permission is hereby granted, free of charge, to any person obtaining a copy
+* of this software and associated documentation files (the "Software"), to deal
+* in the Software without restriction, including without limitation the rights
+* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+* copies of the Software, and to permit persons to whom the Software is
+* furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included in all
+* copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+* WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+* MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+* ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+* WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+* ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+* OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+*/
+
+#include "ProxyConnection.h"
+#include "util/kmtrace.h"
+#include "http/Uri.h"
+
+
+#if defined(KUMA_OS_WIN)
+# include <windows.h>
+#elif defined(KUMA_OS_LINUX)
+
+#elif defined(KUMA_OS_MAC)
+
+#else
+# error "UNSUPPORTED OS"
+#endif
+
+using namespace kuma;
+
+ProxyConnection::Impl::Impl(const EventLoopPtr &loop)
+: TcpConnection(loop)
+{
+    TcpConnection::setDataCallback([this](uint8_t *data, size_t size) {
+        return onTcpData(data, size);
+    });
+    TcpConnection::setWriteCallback([this] (KMError) {
+        onTcpWrite();
+    });
+    TcpConnection::setErrorCallback([this] (KMError err) {
+        onTcpError(err);
+    });
+    
+    http_parser_.setDataCallback([this] (KMBuffer &buf) { onHttpData(buf); });
+    http_parser_.setEventCallback([this] (HttpEvent ev) { onHttpEvent(ev); });
+}
+
+ProxyConnection::Impl::~Impl()
+{
+    
+}
+
+KMError ProxyConnection::Impl::setProxyInfo(const std::string &proxy_url, const std::string &user, const std::string &passwd)
+{
+    Uri uri;
+    if (!uri.parse(proxy_url)) {
+        return KMError::INVALID_PARAM;
+    }
+    proxy_addr_ = uri.getHost();
+    proxy_port_ = static_cast<uint16_t>(std::stoi(uri.getPort()));
+    proxy_user_ = user;
+    proxy_passwd_ = passwd;
+    return KMError::NOERR;
+}
+
+KMError ProxyConnection::Impl::connect(const std::string &host, uint16_t port, EventCallback cb)
+{
+    connect_host_ = host;
+    connect_port_ = port;
+    proxy_connect_cb_ = std::move(cb);
+    
+    setState(State::CONNECTING);
+    return TcpConnection::connect(proxy_addr_, proxy_port_, [this] (KMError err) {
+        onTcpConnect(err);
+    });
+}
+
+KMError ProxyConnection::Impl::sendProxyRequest()
+{
+    setState(State::AUTHENTICATING);
+    auto req = buildProxyRequest();
+    auto ret = TcpConnection::send(req.c_str(), req.size());
+    if (ret < 0) {
+        return KMError::FAILED;
+    }
+    return KMError::NOERR;
+}
+
+std::string ProxyConnection::Impl::buildProxyRequest()
+{
+    std::stringstream ss;
+    ss << "CONNECT " << connect_host_ << ":" << connect_port_ << " HTTP/1.1\r\n";
+    ss << "User-Agent: " << UserAgent << "\r\n";
+    if (!host_.empty()) {
+        ss << "Host: " << connect_host_ << ":" << connect_port_ << "\r\n";
+    }
+    ss << "Content-Length: 0" << "\r\n";
+    ss << "Proxy-Connection: Keep-Alive" << "\r\n";
+    ss << "Pragma: no-cache" << "\r\n";
+    if (proxy_auth_ && proxy_auth_->hasAuthHeader()) {
+        auto auth_header = proxy_auth_->getAuthHeader();
+        if (!auth_header.empty()) {
+            ss << strProxyAuthorization << ": " << auth_header << "\r\n";
+        }
+    }
+    ss << "\r\n";
+    return ss.str();
+}
+
+KMError ProxyConnection::Impl::handleProxyResponse()
+{
+    if (http_parser_.getStatusCode() == 407) {
+        auto str_conn = http_parser_.getHeaderValue("Connection");
+        if (str_conn.empty()) {
+            str_conn = http_parser_.getHeaderValue(strProxyConnection);
+        }
+        bool need_reconnect = is_equal(str_conn, "Close");
+        std::string scheme, chellage;
+        http_parser_.forEachHeader([&scheme, &chellage] (const std::string &name, const std::string &value) {
+            if (is_equal(name, strProxyAuthenticate)) {
+                const auto pos = value.find(' ');
+                const auto s = value.substr(0, pos);
+                if (is_equal(s, "NTLM") ||
+                    is_equal(s, "Negotiate") ||
+                    is_equal(s, "Basic")) {
+                    scheme = std::move(s);
+                    if (pos != std::string::npos) {
+                        chellage = value.substr(pos + 1);
+                    }
+                    return false;
+                }
+            }
+            return true;
+        });
+        if (scheme.empty()) {
+            return KMError::FAILED;
+        }
+        if (!proxy_auth_) {
+            proxy_auth_ = ProxyAuthenticator::create(scheme, proxy_user_, proxy_passwd_);
+            if (!proxy_auth_) {
+                return KMError::FAILED;
+            }
+        }
+        proxy_auth_->nextAuthToken(chellage);
+        
+        if (need_reconnect) {
+            TcpConnection::close();
+            http_parser_.reset();
+            
+            setState(State::CONNECTING);
+            auto ret = TcpConnection::connect(proxy_addr_, proxy_port_, [this] (KMError err) {
+                onTcpConnect(err);
+            });
+            if (ret != KMError::NOERR) {
+                onProxyConnect(ret);
+            }
+        } else {
+            sendProxyRequest();
+        }
+    } else if (http_parser_.getStatusCode() == 200) {
+        onProxyConnect(KMError::NOERR);
+    }
+    return KMError::NOERR;
+}
+
+void ProxyConnection::Impl::onTcpConnect(KMError err)
+{
+    if (err == KMError::NOERR) {
+        auto ret = sendProxyRequest();
+        if (ret != KMError::NOERR) {
+            onProxyConnect(KMError::FAILED);
+        }
+    } else {
+        onProxyConnect(err);
+    }
+}
+
+KMError ProxyConnection::Impl::onTcpData(uint8_t *data, size_t size)
+{
+    if (getState() == State::OPEN) {
+        onProxyData(data, size);
+    } else if (getState() == State::AUTHENTICATING) {
+        int bytes_used = http_parser_.parse((char*)data, size);
+    }
+    return KMError::NOERR;
+}
+
+void ProxyConnection::Impl::onTcpWrite()
+{
+    onProxyWrite();
+}
+
+void ProxyConnection::Impl::onTcpError(KMError err)
+{
+    onProxyError(err);
+}
+
+void ProxyConnection::Impl::onProxyConnect(KMError err)
+{
+    if (err == KMError::NOERR) {
+        setState(State::OPEN);
+    }
+    if (proxy_connect_cb_) {
+        proxy_connect_cb_(err);
+    }
+}
+
+void ProxyConnection::Impl::onProxyData(uint8_t *data, size_t size)
+{
+    if (proxy_data_cb_) {
+        proxy_data_cb_(data, size);
+    }
+}
+
+void ProxyConnection::Impl::onProxyWrite()
+{
+    if (getState() == State::OPEN && proxy_write_cb_) {
+        proxy_write_cb_(KMError::NOERR);
+    }
+}
+
+void ProxyConnection::Impl::onProxyError(KMError err)
+{
+    if (proxy_error_cb_) {
+        proxy_error_cb_(err);
+    }
+}
+
+void ProxyConnection::Impl::onHttpData(KMBuffer &buf)
+{
+    
+}
+
+void ProxyConnection::Impl::onHttpEvent(HttpEvent ev)
+{
+    KUMA_INFOTRACE("onHttpEvent, ev="<<int(ev));
+    switch (ev) {
+        case HttpEvent::HEADER_COMPLETE:
+            break;
+            
+        case HttpEvent::COMPLETE:
+            handleProxyResponse();
+            break;
+            
+        case HttpEvent::HTTP_ERROR:
+            break;
+            
+        default:
+            break;
+    }
+}

--- a/src/proxy/ProxyConnection.h
+++ b/src/proxy/ProxyConnection.h
@@ -1,0 +1,97 @@
+/* Copyright (c) 2014-2019, Fengping Bao <jamol@live.com>
+*
+* Permission is hereby granted, free of charge, to any person obtaining a copy
+* of this software and associated documentation files (the "Software"), to deal
+* in the Software without restriction, including without limitation the rights
+* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+* copies of the Software, and to permit persons to whom the Software is
+* furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included in all
+* copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+* WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+* MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+* ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+* WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+* ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+* OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+*/
+
+#pragma once
+
+#include "kmdefs.h"
+#include "EventLoopImpl.h"
+#include "TcpConnection.h"
+#include "http/HttpParserImpl.h"
+#include "ProxyAuthenticator.h"
+
+KUMA_NS_BEGIN
+
+class ProxyConnection::Impl : public TcpConnection
+{
+public:
+    using EventCallback = ProxyConnection::EventCallback;
+    using DataCallback = ProxyConnection::DataCallback;
+
+    Impl(const EventLoopPtr &loop);
+    virtual ~Impl();
+    
+    KMError setProxyInfo(const std::string &proxy_url, const std::string &user, const std::string &passwd);
+    KMError connect(const std::string &host, uint16_t port, EventCallback cb) override;
+    
+    void setDataCallback(DataCallback cb) override { proxy_data_cb_ = std::move(cb); }
+    void setWriteCallback(EventCallback cb) override { proxy_write_cb_ = std::move(cb); }
+    void setErrorCallback(EventCallback cb) override { proxy_error_cb_ = std::move(cb); }
+    
+protected: // callbacks of TcpConnection
+    void onTcpConnect(KMError err);
+    KMError onTcpData(uint8_t *data, size_t size);
+    void onTcpWrite();
+    void onTcpError(KMError err);
+    
+protected:
+    KMError sendProxyRequest();
+    std::string buildProxyRequest();
+    KMError handleProxyResponse();
+    
+    void onProxyConnect(KMError err);
+    void onProxyData(uint8_t *data, size_t size);
+    void onProxyWrite();
+    void onProxyError(KMError err);
+    
+    void onHttpData(KMBuffer &buf);
+    void onHttpEvent(HttpEvent ev);
+    
+    enum class State
+    {
+        IDLE,
+        CONNECTING,
+        AUTHENTICATING,
+        OPEN,
+        CLOSED
+    };
+    void setState(State state) { state_ = state; }
+    State getState() const { return state_; }
+    
+private:
+    State                   state_ = State::IDLE;
+    std::string             connect_host_;
+    uint16_t                connect_port_;
+    std::string             proxy_addr_;
+    uint16_t                proxy_port_;
+    std::string             proxy_user_; // domain\user
+    std::string             proxy_passwd_;
+    HttpParser::Impl        http_parser_;
+    std::unique_ptr<ProxyAuthenticator> proxy_auth_;
+    
+    bool                    need_reconnect_ = false;
+    
+    EventCallback           proxy_connect_cb_;
+    DataCallback            proxy_data_cb_;
+    EventCallback           proxy_write_cb_;
+    EventCallback           proxy_error_cb_;
+};
+
+KUMA_NS_END

--- a/src/proxy/ProxyConnectionImpl.h
+++ b/src/proxy/ProxyConnectionImpl.h
@@ -91,6 +91,7 @@ private:
     
     bool                    need_reconnect_ = false;
     uint32_t                proxy_ssl_flags_ = 0;
+    uint32_t                num_of_attempts_ = 0;
     
     EventCallback           proxy_connect_cb_;
     DataCallback            proxy_data_cb_;

--- a/src/proxy/SspiAuthenticator.cpp
+++ b/src/proxy/SspiAuthenticator.cpp
@@ -108,6 +108,7 @@ bool SspiAuthenticator::init(const AuthInfo &auth_info, const RequestInfo &req_i
         &expiry);
 
     if (!(SEC_SUCCESS(status))) {
+        KUMA_ERRXTRACE("init, AcquireCredentialsHandle failed, status=" << status);
         return false;
     }
 
@@ -131,7 +132,7 @@ bool SspiAuthenticator::nextAuthToken(const std::string& challenge)
     out_sec_buf.pvBuffer = 0;
 
     std::string target;
-    if (false && auth_scheme_ == AuthScheme::DIGEST)
+    if (auth_scheme_ == AuthScheme::DIGEST)
     {
         target = req_info_.path; // Service Principle Name
     }
@@ -207,12 +208,14 @@ bool SspiAuthenticator::nextAuthToken(const std::string& challenge)
         status = ::CompleteAuthToken(&ctxt_handle_, &out_sec_buf_desc);
         if (!SEC_SUCCESS(status))
         {
+            KUMA_ERRXTRACE("nextAuthToken, InitializeSecurityContext failed, status=" << status);
             return false;
         }
     }
 
     if (!out_sec_buf.pvBuffer)
     {
+        KUMA_ERRXTRACE("nextAuthToken, the output security buffer is null");
         return false;
     }
 

--- a/src/proxy/SspiAuthenticator.cpp
+++ b/src/proxy/SspiAuthenticator.cpp
@@ -32,43 +32,64 @@
 
 using namespace kuma;
 
+static std::string getSecurityStatusString(SECURITY_STATUS status);
+
 SspiAuthenticator::SspiAuthenticator()
 {
+    SecInvalidateHandle(&cred_handle_);
+    SecInvalidateHandle(&ctxt_handle_);
+
     KM_SetObjKey("SspiAuthenticator");
 }
 
 SspiAuthenticator::~SspiAuthenticator()
 {
-    if (initialized_) {
+    cleanup();
+}
+
+void SspiAuthenticator::cleanup()
+{
+    if (SecIsValidHandle(&ctxt_handle_)) {
+        ::DeleteSecurityContext(&ctxt_handle_);
+        SecInvalidateHandle(&ctxt_handle_);
+    }
+    if (SecIsValidHandle(&cred_handle_)) {
         ::FreeCredentialsHandle(&cred_handle_);
+        SecInvalidateHandle(&cred_handle_);
     }
 }
 
-bool SspiAuthenticator::init(const std::string& proxy_name, const std::string& auth_scheme, const std::string &domain_user, const std::string &password)
+bool SspiAuthenticator::init(const AuthInfo &auth_info, const RequestInfo &req_info)
 {
-    proxy_name_ = proxy_name;
-    auth_scheme_ = auth_scheme;
+    cleanup();
+
+    auth_scheme_ = auth_info.scheme;
+    req_info_ = req_info;
 
     TimeStamp expiry;
     SEC_WINNT_AUTH_IDENTITY auth_data;
     PVOID p_auth_data = nullptr;
+    std::string package_name = getAuthScheme(auth_scheme_);
+    if (auth_scheme_ == AuthScheme::DIGEST) {
+        package_name = "WDigest";
+    }
 
-    if (!domain_user.empty() && is_equal(auth_scheme, "NTLM")) {
+    if (!auth_info.user.empty()) {
         memset(&auth_data, 0, sizeof(auth_data));
-        const auto back_slash_pos = domain_user.find_first_of("\\");
+        const auto back_slash_pos = auth_info.user.find_first_of("\\");
         if (back_slash_pos != std::string::npos) {
-            auth_data.Domain = (unsigned char*)domain_user.c_str();
+            auth_data.Domain = (unsigned char*)auth_info.user.c_str();
             auth_data.DomainLength = (unsigned long)back_slash_pos;
             auth_data.User = auth_data.Domain + auth_data.DomainLength + 1;
-            auth_data.UserLength = (unsigned long)domain_user.size() - auth_data.DomainLength - 1;
+            auth_data.UserLength = (unsigned long)auth_info.user.size() - auth_data.DomainLength - 1;
         }
         else {
-            auth_data.User = (unsigned char*)domain_user.c_str();
-            auth_data.UserLength = (unsigned long)domain_user.size();
+            auth_data.User = (unsigned char*)auth_info.user.c_str();
+            auth_data.UserLength = (unsigned long)auth_info.user.size();
         }
-        if (!password.empty()) {
-            auth_data.Password = (unsigned char*)password.c_str();
-            auth_data.PasswordLength = (unsigned long)password.size();
+        if (!auth_info.passwd.empty()) {
+            auth_data.Password = (unsigned char*)auth_info.passwd.c_str();
+            auth_data.PasswordLength = (unsigned long)auth_info.passwd.size();
         }
         auth_data.Flags = SEC_WINNT_AUTH_IDENTITY_ANSI;
 
@@ -77,7 +98,7 @@ bool SspiAuthenticator::init(const std::string& proxy_name, const std::string& a
 
     auto status = ::AcquireCredentialsHandleA(
         NULL,
-        (SEC_CHAR *)auth_scheme.c_str(),
+        (SEC_CHAR *)package_name.c_str(),
         SECPKG_CRED_OUTBOUND,
         NULL,
         p_auth_data,
@@ -90,7 +111,6 @@ bool SspiAuthenticator::init(const std::string& proxy_name, const std::string& a
         return false;
     }
 
-    initialized_ = true;
     return true;
 }
 
@@ -110,11 +130,13 @@ bool SspiAuthenticator::nextAuthToken(const std::string& challenge)
     out_sec_buf.BufferType = SECBUFFER_TOKEN;
     out_sec_buf.pvBuffer = 0;
 
-    std::string target{ "InetSvcs" };
-
-    if (is_equal(auth_scheme_, "Negotiate"))
+    std::string target;
+    if (false && auth_scheme_ == AuthScheme::DIGEST)
     {
-        target = "http/" + proxy_name_; // Service Principle Name
+        target = req_info_.path; // Service Principle Name
+    }
+    else {
+        target = req_info_.service + "/" + req_info_.host; // Service Principle Name
     }
 
     if (challenge.empty())
@@ -122,7 +144,7 @@ bool SspiAuthenticator::nextAuthToken(const std::string& challenge)
         status = ::InitializeSecurityContextA(
             &cred_handle_,
             NULL,
-            (SEC_CHAR *)target.c_str(),
+            (SEC_CHAR *)(target.empty() ? nullptr : target.c_str()),
             ISC_REQ_ALLOCATE_MEMORY, //ISC_REQ_CONFIDENTIALITY ,
             0,
             SECURITY_NETWORK_DREP, //SECURITY_NATIVE_DREP,
@@ -135,26 +157,43 @@ bool SspiAuthenticator::nextAuthToken(const std::string& challenge)
     }
     else
     {
-        auto decoded_challenge = x64_decode(challenge);
+        std::string decoded_challenge;
+        if (auth_scheme_ == AuthScheme::DIGEST) {
+            std::string realm, nonce, qop;
+            parseDigestChallenge(challenge, realm, nonce, qop);
+            decoded_challenge = challenge;
+        }
+        else {
+            decoded_challenge = x64_decode(challenge);
+        }
 
         SecBufferDesc     in_sec_buf_desc;
-        SecBuffer         in_sec_buf;
+        SecBuffer         in_sec_buf[3];
 
         in_sec_buf_desc.ulVersion = 0;
         in_sec_buf_desc.cBuffers = 1;
-        in_sec_buf_desc.pBuffers = &in_sec_buf;
+        in_sec_buf_desc.pBuffers = in_sec_buf;
 
-        in_sec_buf.cbBuffer = (unsigned long)decoded_challenge.size();
-        in_sec_buf.BufferType = SECBUFFER_TOKEN;
-        in_sec_buf.pvBuffer = (BYTE *)decoded_challenge.data();
+        in_sec_buf[0].cbBuffer = (unsigned long)decoded_challenge.size();
+        in_sec_buf[0].BufferType = SECBUFFER_TOKEN;
+        in_sec_buf[0].pvBuffer = (BYTE *)decoded_challenge.data();
+        if (auth_scheme_ == AuthScheme::DIGEST) {
+            in_sec_buf_desc.cBuffers = 3;
+            in_sec_buf[1].BufferType = SECBUFFER_PKG_PARAMS;
+            in_sec_buf[1].pvBuffer = const_cast<char*>(req_info_.method.c_str());
+            in_sec_buf[1].cbBuffer = static_cast<unsigned long>(req_info_.method.size());
+            in_sec_buf[2].BufferType = SECBUFFER_PKG_PARAMS;
+            in_sec_buf[2].pvBuffer = NULL;
+            in_sec_buf[2].cbBuffer = 0;
+        }
 
         status = ::InitializeSecurityContextA(
             &cred_handle_,
-            &ctxt_handle_,
+            SecIsValidHandle(&ctxt_handle_) ? &ctxt_handle_ : nullptr,
             (SEC_CHAR *)target.c_str(),
-            ISC_REQ_ALLOCATE_MEMORY, //ISC_REQ_CONFIDENTIALITY,
+            ISC_REQ_ALLOCATE_MEMORY | ISC_REQ_USE_HTTP_STYLE,
             0,
-            SECURITY_NETWORK_DREP, // SECURITY_NATIVE_DREP,
+            SECURITY_NETWORK_DREP,
             &in_sec_buf_desc,
             0,
             &ctxt_handle_,
@@ -177,7 +216,12 @@ bool SspiAuthenticator::nextAuthToken(const std::string& challenge)
         return false;
     }
 
-    auth_token_ = x64_encode(out_sec_buf.pvBuffer, out_sec_buf.cbBuffer, false);
+    if (auth_scheme_ == AuthScheme::DIGEST) {
+        auth_token_.assign((char*)out_sec_buf.pvBuffer, out_sec_buf.cbBuffer);
+    }
+    else {
+        auth_token_ = x64_encode(out_sec_buf.pvBuffer, out_sec_buf.cbBuffer, false);
+    }
 
     ::FreeContextBuffer(out_sec_buf.pvBuffer);
 
@@ -189,7 +233,7 @@ bool SspiAuthenticator::nextAuthToken(const std::string& challenge)
 std::string SspiAuthenticator::getAuthHeader() const
 {
     if (hasAuthHeader()) {
-        return auth_scheme_ + " " + auth_token_;
+        return getAuthScheme(auth_scheme_) + " " + auth_token_;
     }
 
     return "";
@@ -197,5 +241,300 @@ std::string SspiAuthenticator::getAuthHeader() const
 
 bool SspiAuthenticator::hasAuthHeader() const
 {
+    return !auth_token_.empty();
+}
+
+bool SspiAuthenticator::parseDigestChallenge(const std::string &challenge, std::string &realm, std::string &nonce, std::string qop)
+{
+    for_each_token(challenge, ',', [&nonce, &realm, &qop](std::string &t) {
+        std::string k, v;
+        auto pos = t.find('=');
+        if (pos == std::string::npos) {
+            return true;
+        }
+        k = t.substr(0, pos);
+        if (t[++pos] == '\"') {
+            ++pos;
+        }
+        auto sz = t.size();
+        if (t[sz - 1] == '\"' && (sz - 1) > pos) {
+            v = t.substr(pos, sz - 1 - pos);
+        }
+        else {
+            v = t.substr(pos);
+        }
+        if (is_equal(k, "nonce")) {
+            nonce = v;
+        }
+        else if (is_equal(k, "realm")) {
+            realm = v;
+        }
+        else if (is_equal(k, "qop")) {
+            qop = v;
+        }
+        return true;
+    });
+
     return true;
 }
+
+static std::string getSecurityStatusString(SECURITY_STATUS status)
+{
+    switch (status)
+    {
+    case SEC_E_OK:
+        return "SEC_E_OK";
+
+    case SEC_E_INSUFFICIENT_MEMORY:
+        return "SEC_E_INSUFFICIENT_MEMORY";
+
+    case SEC_E_INVALID_HANDLE:
+        return "SEC_E_INVALID_HANDLE";
+
+    case SEC_E_UNSUPPORTED_FUNCTION:
+        return "SEC_E_UNSUPPORTED_FUNCTION";
+
+    case SEC_E_TARGET_UNKNOWN:
+        return "SEC_E_TARGET_UNKNOWN";
+
+    case SEC_E_INTERNAL_ERROR:
+        return "SEC_E_INTERNAL_ERROR";
+
+    case SEC_E_SECPKG_NOT_FOUND:
+        return "SEC_E_SECPKG_NOT_FOUND";
+
+    case SEC_E_NOT_OWNER:
+        return "SEC_E_NOT_OWNER";
+
+    case SEC_E_CANNOT_INSTALL:
+        return "SEC_E_CANNOT_INSTALL";
+
+    case SEC_E_INVALID_TOKEN:
+        return "SEC_E_INVALID_TOKEN";
+
+    case SEC_E_CANNOT_PACK:
+        return "SEC_E_CANNOT_PACK";
+
+    case SEC_E_QOP_NOT_SUPPORTED:
+        return "SEC_E_QOP_NOT_SUPPORTED";
+
+    case SEC_E_NO_IMPERSONATION:
+        return "SEC_E_NO_IMPERSONATION";
+
+    case SEC_E_LOGON_DENIED:
+        return "SEC_E_LOGON_DENIED";
+
+    case SEC_E_UNKNOWN_CREDENTIALS:
+        return "SEC_E_UNKNOWN_CREDENTIALS";
+
+    case SEC_E_NO_CREDENTIALS:
+        return "SEC_E_NO_CREDENTIALS";
+
+    case SEC_E_MESSAGE_ALTERED:
+        return "SEC_E_MESSAGE_ALTERED";
+
+    case SEC_E_OUT_OF_SEQUENCE:
+        return "SEC_E_OUT_OF_SEQUENCE";
+
+    case SEC_E_NO_AUTHENTICATING_AUTHORITY:
+        return "SEC_E_NO_AUTHENTICATING_AUTHORITY";
+
+    case SEC_E_BAD_PKGID:
+        return "SEC_E_BAD_PKGID";
+
+    case SEC_E_CONTEXT_EXPIRED:
+        return "SEC_E_CONTEXT_EXPIRED";
+
+    case SEC_E_INCOMPLETE_MESSAGE:
+        return "SEC_E_INCOMPLETE_MESSAGE";
+
+    case SEC_E_INCOMPLETE_CREDENTIALS:
+        return "SEC_E_INCOMPLETE_CREDENTIALS";
+
+    case SEC_E_BUFFER_TOO_SMALL:
+        return "SEC_E_BUFFER_TOO_SMALL";
+
+    case SEC_E_WRONG_PRINCIPAL:
+        return "SEC_E_WRONG_PRINCIPAL";
+
+    case SEC_E_TIME_SKEW:
+        return "SEC_E_TIME_SKEW";
+
+    case SEC_E_UNTRUSTED_ROOT:
+        return "SEC_E_UNTRUSTED_ROOT";
+
+    case SEC_E_ILLEGAL_MESSAGE:
+        return "SEC_E_ILLEGAL_MESSAGE";
+
+    case SEC_E_CERT_UNKNOWN:
+        return "SEC_E_CERT_UNKNOWN";
+
+    case SEC_E_CERT_EXPIRED:
+        return "SEC_E_CERT_EXPIRED";
+
+    case SEC_E_ENCRYPT_FAILURE:
+        return "SEC_E_ENCRYPT_FAILURE";
+
+    case SEC_E_DECRYPT_FAILURE:
+        return "SEC_E_DECRYPT_FAILURE";
+
+    case SEC_E_ALGORITHM_MISMATCH:
+        return "SEC_E_ALGORITHM_MISMATCH";
+
+    case SEC_E_SECURITY_QOS_FAILED:
+        return "SEC_E_SECURITY_QOS_FAILED";
+
+    case SEC_E_UNFINISHED_CONTEXT_DELETED:
+        return "SEC_E_UNFINISHED_CONTEXT_DELETED";
+
+    case SEC_E_NO_TGT_REPLY:
+        return "SEC_E_NO_TGT_REPLY";
+
+    case SEC_E_NO_IP_ADDRESSES:
+        return "SEC_E_NO_IP_ADDRESSES";
+
+    case SEC_E_WRONG_CREDENTIAL_HANDLE:
+        return "SEC_E_WRONG_CREDENTIAL_HANDLE";
+
+    case SEC_E_CRYPTO_SYSTEM_INVALID:
+        return "SEC_E_CRYPTO_SYSTEM_INVALID";
+
+    case SEC_E_MAX_REFERRALS_EXCEEDED:
+        return "SEC_E_MAX_REFERRALS_EXCEEDED";
+
+    case SEC_E_MUST_BE_KDC:
+        return "SEC_E_MUST_BE_KDC";
+
+    case SEC_E_STRONG_CRYPTO_NOT_SUPPORTED:
+        return "SEC_E_STRONG_CRYPTO_NOT_SUPPORTED";
+
+    case SEC_E_TOO_MANY_PRINCIPALS:
+        return "SEC_E_TOO_MANY_PRINCIPALS";
+
+    case SEC_E_NO_PA_DATA:
+        return "SEC_E_NO_PA_DATA";
+
+    case SEC_E_PKINIT_NAME_MISMATCH:
+        return "SEC_E_PKINIT_NAME_MISMATCH";
+
+    case SEC_E_SMARTCARD_LOGON_REQUIRED:
+        return "SEC_E_SMARTCARD_LOGON_REQUIRED";
+
+    case SEC_E_SHUTDOWN_IN_PROGRESS:
+        return "SEC_E_SHUTDOWN_IN_PROGRESS";
+
+    case SEC_E_KDC_INVALID_REQUEST:
+        return "SEC_E_KDC_INVALID_REQUEST";
+
+    case SEC_E_KDC_UNABLE_TO_REFER:
+        return "SEC_E_KDC_UNABLE_TO_REFER";
+
+    case SEC_E_KDC_UNKNOWN_ETYPE:
+        return "SEC_E_KDC_UNKNOWN_ETYPE";
+
+    case SEC_E_UNSUPPORTED_PREAUTH:
+        return "SEC_E_UNSUPPORTED_PREAUTH";
+
+    case SEC_E_DELEGATION_REQUIRED:
+        return "SEC_E_DELEGATION_REQUIRED";
+
+    case SEC_E_BAD_BINDINGS:
+        return "SEC_E_BAD_BINDINGS";
+
+    case SEC_E_MULTIPLE_ACCOUNTS:
+        return "SEC_E_MULTIPLE_ACCOUNTS";
+
+    case SEC_E_NO_KERB_KEY:
+        return "SEC_E_NO_KERB_KEY";
+
+    case SEC_E_CERT_WRONG_USAGE:
+        return "SEC_E_CERT_WRONG_USAGE";
+
+    case SEC_E_DOWNGRADE_DETECTED:
+        return "SEC_E_DOWNGRADE_DETECTED";
+
+    case SEC_E_SMARTCARD_CERT_REVOKED:
+        return "SEC_E_SMARTCARD_CERT_REVOKED";
+
+    case SEC_E_ISSUING_CA_UNTRUSTED:
+        return "SEC_E_ISSUING_CA_UNTRUSTED";
+
+    case SEC_E_REVOCATION_OFFLINE_C:
+        return "SEC_E_REVOCATION_OFFLINE_C";
+
+    case SEC_E_PKINIT_CLIENT_FAILURE:
+        return "SEC_E_PKINIT_CLIENT_FAILURE";
+
+    case SEC_E_SMARTCARD_CERT_EXPIRED:
+        return "SEC_E_SMARTCARD_CERT_EXPIRED";
+
+    case SEC_E_NO_S4U_PROT_SUPPORT:
+        return "SEC_E_NO_S4U_PROT_SUPPORT";
+
+    case SEC_E_CROSSREALM_DELEGATION_FAILURE:
+        return "SEC_E_CROSSREALM_DELEGATION_FAILURE";
+
+    case SEC_E_REVOCATION_OFFLINE_KDC:
+        return "SEC_E_REVOCATION_OFFLINE_KDC";
+
+    case SEC_E_ISSUING_CA_UNTRUSTED_KDC:
+        return "SEC_E_ISSUING_CA_UNTRUSTED_KDC";
+
+    case SEC_E_KDC_CERT_EXPIRED:
+        return "SEC_E_KDC_CERT_EXPIRED";
+
+    case SEC_E_KDC_CERT_REVOKED:
+        return "SEC_E_KDC_CERT_REVOKED";
+
+    case SEC_E_INVALID_PARAMETER:
+        return "SEC_E_INVALID_PARAMETER";
+
+    case SEC_E_DELEGATION_POLICY:
+        return "SEC_E_DELEGATION_POLICY";
+
+    case SEC_E_POLICY_NLTM_ONLY:
+        return "SEC_E_POLICY_NLTM_ONLY";
+
+    case SEC_E_NO_CONTEXT:
+        return "SEC_E_NO_CONTEXT";
+
+    case SEC_E_PKU2U_CERT_FAILURE:
+        return "SEC_E_PKU2U_CERT_FAILURE";
+
+    case SEC_E_MUTUAL_AUTH_FAILED:
+        return "SEC_E_MUTUAL_AUTH_FAILED";
+
+    case SEC_I_CONTINUE_NEEDED:
+        return "SEC_I_CONTINUE_NEEDED";
+
+    case SEC_I_COMPLETE_NEEDED:
+        return "SEC_I_COMPLETE_NEEDED";
+
+    case SEC_I_COMPLETE_AND_CONTINUE:
+        return "SEC_I_COMPLETE_AND_CONTINUE";
+
+    case SEC_I_LOCAL_LOGON:
+        return "SEC_I_LOCAL_LOGON";
+
+    case SEC_I_CONTEXT_EXPIRED:
+        return "SEC_I_CONTEXT_EXPIRED";
+
+    case SEC_I_INCOMPLETE_CREDENTIALS:
+        return "SEC_I_INCOMPLETE_CREDENTIALS";
+
+    case SEC_I_RENEGOTIATE:
+        return "SEC_I_RENEGOTIATE";
+
+    case SEC_I_NO_LSA_CONTEXT:
+        return "SEC_I_NO_LSA_CONTEXT";
+
+    case SEC_I_SIGNATURE_NEEDED:
+        return "SEC_I_SIGNATURE_NEEDED";
+
+    case SEC_I_NO_RENEGOTIATION:
+        return "SEC_I_NO_RENEGOTIATION";
+    }
+
+    return "SEC_E_UNKNOWN_" + std::to_string(status);
+}
+

--- a/src/proxy/SspiAuthenticator.cpp
+++ b/src/proxy/SspiAuthenticator.cpp
@@ -1,0 +1,201 @@
+/* Copyright (c) 2014-2019, Fengping Bao <jamol@live.com>
+*
+* Permission is hereby granted, free of charge, to any person obtaining a copy
+* of this software and associated documentation files (the "Software"), to deal
+* in the Software without restriction, including without limitation the rights
+* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+* copies of the Software, and to permit persons to whom the Software is
+* furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included in all
+* copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+* WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+* MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+* ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+* WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+* ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+* OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+*/
+
+#include "SspiAuthenticator.h"
+#include "util/util.h"
+#include "util/kmtrace.h"
+#include "util/base64.h"
+
+
+#pragma comment(lib, "Secur32.lib")
+
+#define SEC_SUCCESS(status) ((status) >= 0)
+
+
+using namespace kuma;
+
+SspiAuthenticator::SspiAuthenticator()
+{
+    KM_SetObjKey("SspiAuthenticator");
+}
+
+SspiAuthenticator::~SspiAuthenticator()
+{
+    if (initialized_) {
+        ::FreeCredentialsHandle(&cred_handle_);
+    }
+}
+
+bool SspiAuthenticator::init(const std::string& proxy_name, const std::string& auth_scheme, const std::string &domain_user, const std::string &password)
+{
+    proxy_name_ = proxy_name;
+    auth_scheme_ = auth_scheme;
+
+    TimeStamp expiry;
+    SEC_WINNT_AUTH_IDENTITY auth_data;
+    PVOID p_auth_data = nullptr;
+
+    if (!domain_user.empty() && is_equal(auth_scheme, "NTLM")) {
+        memset(&auth_data, 0, sizeof(auth_data));
+        const auto back_slash_pos = domain_user.find_first_of("\\");
+        if (back_slash_pos != std::string::npos) {
+            auth_data.Domain = (unsigned char*)domain_user.c_str();
+            auth_data.DomainLength = (unsigned long)back_slash_pos;
+            auth_data.User = auth_data.Domain + auth_data.DomainLength + 1;
+            auth_data.UserLength = (unsigned long)domain_user.size() - auth_data.DomainLength - 1;
+        }
+        else {
+            auth_data.User = (unsigned char*)domain_user.c_str();
+            auth_data.UserLength = (unsigned long)domain_user.size();
+        }
+        if (!password.empty()) {
+            auth_data.Password = (unsigned char*)password.c_str();
+            auth_data.PasswordLength = (unsigned long)password.size();
+        }
+        auth_data.Flags = SEC_WINNT_AUTH_IDENTITY_ANSI;
+
+        p_auth_data = &auth_data;
+    }
+
+    auto status = ::AcquireCredentialsHandleA(
+        NULL,
+        (SEC_CHAR *)auth_scheme.c_str(),
+        SECPKG_CRED_OUTBOUND,
+        NULL,
+        p_auth_data,
+        NULL,
+        NULL,
+        &cred_handle_,
+        &expiry);
+
+    if (!(SEC_SUCCESS(status))) {
+        return false;
+    }
+
+    initialized_ = true;
+    return true;
+}
+
+bool SspiAuthenticator::nextAuthToken(const std::string& challenge)
+{
+    TimeStamp           expiry;
+    SECURITY_STATUS     status;
+    SecBufferDesc       out_sec_buf_desc;
+    SecBuffer           out_sec_buf;
+    ULONG               ctxt_attrs;
+
+    out_sec_buf_desc.ulVersion = SECBUFFER_VERSION;
+    out_sec_buf_desc.cBuffers = 1;
+    out_sec_buf_desc.pBuffers = &out_sec_buf;
+
+    out_sec_buf.cbBuffer = 0;
+    out_sec_buf.BufferType = SECBUFFER_TOKEN;
+    out_sec_buf.pvBuffer = 0;
+
+    std::string target{ "InetSvcs" };
+
+    if (is_equal(auth_scheme_, "Negotiate"))
+    {
+        target = "http/" + proxy_name_; // Service Principle Name
+    }
+
+    if (challenge.empty())
+    {
+        status = ::InitializeSecurityContextA(
+            &cred_handle_,
+            NULL,
+            (SEC_CHAR *)target.c_str(),
+            ISC_REQ_ALLOCATE_MEMORY, //ISC_REQ_CONFIDENTIALITY ,
+            0,
+            SECURITY_NETWORK_DREP, //SECURITY_NATIVE_DREP,
+            NULL,
+            0,
+            &ctxt_handle_,
+            &out_sec_buf_desc,
+            &ctxt_attrs,
+            &expiry);
+    }
+    else
+    {
+        auto decoded_challenge = x64_decode(challenge);
+
+        SecBufferDesc     in_sec_buf_desc;
+        SecBuffer         in_sec_buf;
+
+        in_sec_buf_desc.ulVersion = 0;
+        in_sec_buf_desc.cBuffers = 1;
+        in_sec_buf_desc.pBuffers = &in_sec_buf;
+
+        in_sec_buf.cbBuffer = (unsigned long)decoded_challenge.size();
+        in_sec_buf.BufferType = SECBUFFER_TOKEN;
+        in_sec_buf.pvBuffer = (BYTE *)decoded_challenge.data();
+
+        status = ::InitializeSecurityContextA(
+            &cred_handle_,
+            &ctxt_handle_,
+            (SEC_CHAR *)target.c_str(),
+            ISC_REQ_ALLOCATE_MEMORY, //ISC_REQ_CONFIDENTIALITY,
+            0,
+            SECURITY_NETWORK_DREP, // SECURITY_NATIVE_DREP,
+            &in_sec_buf_desc,
+            0,
+            &ctxt_handle_,
+            &out_sec_buf_desc,
+            &ctxt_attrs,
+            &expiry);
+    }
+
+    if ((SEC_I_COMPLETE_NEEDED == status) || (SEC_I_COMPLETE_AND_CONTINUE == status))
+    {
+        status = ::CompleteAuthToken(&ctxt_handle_, &out_sec_buf_desc);
+        if (!SEC_SUCCESS(status))
+        {
+            return false;
+        }
+    }
+
+    if (!out_sec_buf.pvBuffer)
+    {
+        return false;
+    }
+
+    auth_token_ = x64_encode(out_sec_buf.pvBuffer, out_sec_buf.cbBuffer, false);
+
+    ::FreeContextBuffer(out_sec_buf.pvBuffer);
+
+    bool continueAuthFlow = ((SEC_I_CONTINUE_NEEDED == status) || (SEC_I_COMPLETE_AND_CONTINUE == status));
+
+    return continueAuthFlow;
+}
+
+std::string SspiAuthenticator::getAuthHeader() const
+{
+    if (hasAuthHeader()) {
+        return auth_scheme_ + " " + auth_token_;
+    }
+
+    return "";
+}
+
+bool SspiAuthenticator::hasAuthHeader() const
+{
+    return true;
+}

--- a/src/proxy/SspiAuthenticator.h
+++ b/src/proxy/SspiAuthenticator.h
@@ -1,0 +1,57 @@
+/* Copyright (c) 2014-2019, Fengping Bao <jamol@live.com>
+*
+* Permission is hereby granted, free of charge, to any person obtaining a copy
+* of this software and associated documentation files (the "Software"), to deal
+* in the Software without restriction, including without limitation the rights
+* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+* copies of the Software, and to permit persons to whom the Software is
+* furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included in all
+* copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+* WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+* MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+* ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+* WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+* ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+* OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+*/
+
+#pragma once
+
+#include "kmdefs.h"
+#include "proxy/ProxyAuthenticator.h"
+#include "util/kmobject.h"
+
+#include <string>
+
+#define WIN32_LEAN_AND_MEAN
+#include <Windows.h>
+#define SECURITY_WIN32
+#include <sspi.h>
+
+KUMA_NS_BEGIN
+
+class SspiAuthenticator : public KMObject, public ProxyAuthenticator
+{
+public:
+    SspiAuthenticator();
+    virtual ~SspiAuthenticator();
+
+    bool init(const std::string &proxy_name, const std::string &auth_scheme, const std::string &domain_user, const std::string &password);
+    bool nextAuthToken(const std::string& challenge) override;
+    std::string getAuthHeader() const override;
+    bool hasAuthHeader() const override;
+
+protected:
+    bool            initialized_ = false;
+    std::string     proxy_name_;
+    std::string     auth_scheme_;
+    std::string     auth_token_;
+    CredHandle      cred_handle_{ 0 };
+    CtxtHandle      ctxt_handle_{ 0 };
+};
+
+KUMA_NS_END

--- a/src/proxy/proxydefs.h
+++ b/src/proxy/proxydefs.h
@@ -22,41 +22,14 @@
 #pragma once
 
 #include "kmdefs.h"
-#include "ProxyAuthenticator.h"
-#include "util/kmobject.h"
-
-#include <string>
-
-#include <GSS/gssapi.h>
-#include <GSS/gssapi_krb5.h>
-#include <GSS/gssapi_spnego.h>
-
 
 KUMA_NS_BEGIN
 
-class GssAuthenticator : public KMObject, public ProxyAuthenticator
+struct ProxyInfo
 {
-public:
-    GssAuthenticator();
-    virtual ~GssAuthenticator();
-
-    bool init(const std::string &proxy_name, const std::string &auth_scheme, const std::string &domain_user, const std::string &passwd);
-    bool nextAuthToken(const std::string& challenge) override;
-    std::string getAuthHeader() const override;
-    bool hasAuthHeader() const override;
-
-protected:
-    std::string     proxy_name_;
-    std::string     auth_scheme_;
-    std::string     auth_token_;
-    
-    gss_ctx_id_t    ctx_id_ = GSS_C_NO_CONTEXT;
-    gss_cred_id_t   cred_id_ = GSS_C_NO_CREDENTIAL;
-    OM_uint32       major_status_ = 0;
-    OM_uint32       minor_status_ = 0;
-    gss_OID         mech_oid_ = GSS_C_NO_OID;
-    gss_name_t      gss_domain_name_ = GSS_C_NO_NAME;
-    gss_name_t      gss_user_name_ = GSS_C_NO_NAME;
+    std::string url;
+    std::string user;
+    std::string passwd;
 };
 
 KUMA_NS_END

--- a/src/ws/WSConnection.h
+++ b/src/ws/WSConnection.h
@@ -26,6 +26,7 @@
 #include "kmbuffer.h"
 #include "http/httpdefs.h"
 #include "http/HttpHeader.h"
+#include "proxy/proxydefs.h"
 
 #include <functional>
 
@@ -47,6 +48,7 @@ public:
     const std::string& getSubprotocol() const { return subprotocol_; }
     KMError setExtensions(const std::string& extensions);
     const std::string& getExtensions() const { return extensions_; }
+    virtual KMError setProxyInfo(const ProxyInfo &proxy_info) = 0;
     virtual KMError addHeader(std::string name, std::string value) = 0;
     virtual KMError addHeader(std::string name, uint32_t value) = 0;
     

--- a/src/ws/WSConnection_v1.cpp
+++ b/src/ws/WSConnection_v1.cpp
@@ -69,6 +69,11 @@ void WSConnection_V1::cleanup()
     stream_->close();
 }
 
+KMError WSConnection_V1::setProxyInfo(const ProxyInfo &proxy_info)
+{
+    return stream_->setProxyInfo(proxy_info);
+}
+
 KMError WSConnection_V1::addHeader(std::string name, std::string value)
 {
     return stream_->addHeader(std::move(name), std::move(value));

--- a/src/ws/WSConnection_v1.h
+++ b/src/ws/WSConnection_v1.h
@@ -40,6 +40,7 @@ public:
     {
         return stream_->setSslFlags(ssl_flags);
     }
+    KMError setProxyInfo(const ProxyInfo &proxy_info) override;
     KMError addHeader(std::string name, std::string value) override;
     KMError addHeader(std::string name, uint32_t value) override;
     KMError connect(const std::string& ws_url) override;

--- a/src/ws/WSConnection_v2.cpp
+++ b/src/ws/WSConnection_v2.cpp
@@ -69,6 +69,11 @@ KMError WSConnection_V2::setSslFlags(uint32_t ssl_flags)
     return KMError::NOERR;
 }
 
+KMError WSConnection_V2::setProxyInfo(const ProxyInfo &proxy_info)
+{
+    return stream_->setProxyInfo(proxy_info);
+}
+
 KMError WSConnection_V2::addHeader(std::string name, std::string value)
 {
     return stream_->addHeader(std::move(name), std::move(value));

--- a/src/ws/WSConnection_v2.h
+++ b/src/ws/WSConnection_v2.h
@@ -41,6 +41,7 @@ public:
     ~WSConnection_V2();
     
     KMError setSslFlags(uint32_t ssl_flags) override;
+    KMError setProxyInfo(const ProxyInfo &proxy_info) override;
     KMError addHeader(std::string name, std::string value) override;
     KMError addHeader(std::string name, uint32_t value) override;
     KMError connect(const std::string& ws_url) override;

--- a/src/ws/WebSocketImpl.cpp
+++ b/src/ws/WebSocketImpl.cpp
@@ -86,6 +86,11 @@ KMError WebSocket::Impl::setSslFlags(uint32_t ssl_flags)
     return ws_conn_->setSslFlags(ssl_flags);
 }
 
+KMError WebSocket::Impl::setProxyInfo(const ProxyInfo &proxy_info)
+{
+    return ws_conn_->setProxyInfo(proxy_info);
+}
+
 KMError WebSocket::Impl::connect(const std::string& ws_url)
 {
     if(getState() != State::IDLE && getState() != State::CLOSED) {

--- a/src/ws/WebSocketImpl.h
+++ b/src/ws/WebSocketImpl.h
@@ -57,6 +57,7 @@ public:
     KMError setSubprotocol(const std::string& subprotocol) { return ws_conn_->setSubprotocol(subprotocol); }
     const std::string& getSubprotocol() const { return ws_conn_->getSubprotocol(); }
     const std::string& getExtensions() const { return ws_conn_->getExtensions(); }
+    KMError setProxyInfo(const ProxyInfo &proxy_info);
     KMError addHeader(std::string name, std::string value)
     {
         return ws_conn_->addHeader(std::move(name), std::move(value));

--- a/test/client/HttpClient.cpp
+++ b/test/client/HttpClient.cpp
@@ -3,7 +3,12 @@
 #include <string.h> // for memset
 #include <atomic>
 
+extern std::string g_proxy_url;
+extern std::string g_proxy_user;
+extern std::string g_proxy_passwd;
+
 extern std::string getHttpVersion();
+
 HttpClient::HttpClient(TestLoop* loop, long conn_id)
 : loop_(loop)
 , http_request_(loop->eventLoop(), getHttpVersion().c_str())
@@ -21,6 +26,7 @@ void HttpClient::startRequest(const std::string& url)
     http_request_.setErrorCallback([this] (KMError err) { onClose(err); });
     http_request_.setHeaderCompleteCallback([this] { onHeaderComplete(); });
     http_request_.setResponseCompleteCallback([this] { onRequestComplete(); });
+    http_request_.setProxyInfo(g_proxy_url.c_str(), g_proxy_user.c_str(), g_proxy_passwd.c_str());
     if (url.find("/testdata") != std::string::npos) {
         http_request_.addHeader("Content-Length", 128*1024*1024);
         http_request_.sendRequest("POST", url.c_str());

--- a/test/client/TcpClient.h
+++ b/test/client/TcpClient.h
@@ -14,6 +14,7 @@ class TcpClient : public TestObject
 public:
     TcpClient(TestLoop* loop, long conn_id);
     
+    void setSslFlags(uint32_t ssl_flags) { ssl_flags_ = ssl_flags; }
     KMError bind(const std::string &bind_host, uint16_t bind_port);
     KMError connect(const std::string &host, uint16_t port);
     int close();
@@ -24,15 +25,19 @@ public:
     void onClose(KMError err);
     void onTimer();
     
+    KMError onData(uint8_t *data, size_t size);
+    
 private:
     void sendData();
     
 private:
     TestLoop*   loop_;
     TcpSocket   tcp_;
+    ProxyConnection proxy_conn_;
     
     Timer       timer_;
     
+    uint32_t    ssl_flags_ = 0;
     long        conn_id_;
     
     uint32_t    index_;

--- a/test/client/TestLoop.cpp
+++ b/test/client/TestLoop.cpp
@@ -81,7 +81,7 @@ void TestLoop::startTest_i(const std::string& addr_url, const std::string& bind_
         return ;
     }
     
-    if(strcmp(proto, "tcp") == 0) {
+    if(strcmp(proto, "tcp") == 0 || strcmp(proto, "tcps") == 0) {
         long conn_id = server_->getConnId();
         TcpClient* client = new TcpClient(this, conn_id);
         addObject(conn_id, client);
@@ -91,6 +91,9 @@ void TestLoop::startTest_i(const std::string& addr_url, const std::string& bind_
             if(km_parse_address(bind_addr.c_str(), NULL, 0, bind_host, sizeof(bind_host), &bind_port) == 0) {
                 client->bind(bind_host, bind_port);
             }
+        }
+        if (strcmp(proto, "tcps") == 0) {
+            client->setSslFlags(SSL_ENABLE);
         }
         client->connect(host, port);
     } else if(strcmp(proto, "udp") == 0) {

--- a/test/client/TestLoop.cpp
+++ b/test/client/TestLoop.cpp
@@ -93,6 +93,7 @@ void TestLoop::startTest_i(const std::string& addr_url, const std::string& bind_
             }
         }
         if (strcmp(proto, "tcps") == 0) {
+            if (port == 0) port = 443;
             client->setSslFlags(SSL_ENABLE);
         }
         client->connect(host, port);

--- a/test/client/WsClient.cpp
+++ b/test/client/WsClient.cpp
@@ -6,6 +6,10 @@
 # include <arpa/inet.h>
 #endif
 
+extern std::string g_proxy_url;
+extern std::string g_proxy_user;
+extern std::string g_proxy_passwd;
+
 uint32_t getSendInterval();
 
 extern std::string getHttpVersion();
@@ -30,6 +34,7 @@ void WsClient::startRequest(const std::string& url)
     });
     ws_.setWriteCallback([this] (KMError err) { onSend(err); });
     ws_.setErrorCallback([this] (KMError err) { onClose(err); });
+    ws_.setProxyInfo(g_proxy_url.c_str(), g_proxy_user.c_str(), g_proxy_passwd.c_str());
     ws_.setSubprotocol("jws");
     ws_.setOrigin("www.jamol.cn");
     ws_.addHeader("x-forward-addr", "123");

--- a/test/client/main.cpp
+++ b/test/client/main.cpp
@@ -21,6 +21,9 @@ using namespace kuma;
 #define THREAD_COUNT    10
 static bool g_exit = false;
 bool g_test_http2 = false;
+std::string g_proxy_url;
+std::string g_proxy_user;
+std::string g_proxy_passwd;
 EventLoop main_loop(PollType::NONE);
 
 #ifdef KUMA_OS_WIN
@@ -54,6 +57,9 @@ static const std::string g_usage =
 "   -t ms           send interval\n"
 "   -v              print version\n"
 "   --http2         test http2\n"
+"   --proxy         test proxy setting"
+"   --user          proxy domain user name"
+"   --passwd        proxy password"
 ;
 
 std::vector<std::thread> event_threads;
@@ -125,7 +131,30 @@ int main(int argc, char *argv[])
                     }
                     break;
                 case '-':
-                    g_test_http2 = strcmp(argv[i] + 2, "http2") == 0;
+                    if (strcmp(argv[i] + 2, "http2") == 0) {
+                        g_test_http2 = true;
+                    } else if (strcmp(argv[i] + 2, "proxy") == 0) {
+                        if(++i < argc) {
+                            g_proxy_url = argv[i];
+                        } else {
+                            printUsage();
+                            return -1;
+                        }
+                    } else if (strcmp(argv[i] + 2, "user") == 0) {
+                        if(++i < argc) {
+                            g_proxy_user = argv[i];
+                        } else {
+                            printUsage();
+                            return -1;
+                        }
+                    } else if (strcmp(argv[i] + 2, "passwd") == 0) {
+                        if(++i < argc) {
+                            g_proxy_passwd = argv[i];
+                        } else {
+                            printUsage();
+                            return -1;
+                        }
+                    }
                     break;
                 default:
                     printUsage();

--- a/test/client/main.cpp
+++ b/test/client/main.cpp
@@ -57,9 +57,8 @@ static const std::string g_usage =
 "   -t ms           send interval\n"
 "   -v              print version\n"
 "   --http2         test http2\n"
-"   --proxy         test proxy setting"
-"   --user          proxy domain user name"
-"   --passwd        proxy password"
+"   --proxy         test proxy setting\n"
+"   --proxy-cred    proxy credential \"[domain\\]username[:password]\"\n"
 ;
 
 std::vector<std::thread> event_threads;
@@ -140,16 +139,15 @@ int main(int argc, char *argv[])
                             printUsage();
                             return -1;
                         }
-                    } else if (strcmp(argv[i] + 2, "user") == 0) {
+                    } else if (strcmp(argv[i] + 2, "proxy-cred") == 0) {
                         if(++i < argc) {
-                            g_proxy_user = argv[i];
-                        } else {
-                            printUsage();
-                            return -1;
-                        }
-                    } else if (strcmp(argv[i] + 2, "passwd") == 0) {
-                        if(++i < argc) {
-                            g_proxy_passwd = argv[i];
+                            auto *p = strchr(argv[i], ':');
+                            if (p) {
+                                g_proxy_user = std::string(argv[i], p);
+                                g_proxy_passwd = p + 1;
+                            } else {
+                                g_proxy_user = argv[i];
+                            }
                         } else {
                             printUsage();
                             return -1;


### PR DESCRIPTION
Only support proxy traversal over HTTP tunnel
1. Basic
2. Digest (windows only)
3. NTLM (Windows and Mac)
4. Negotiate (Windows and Mac)