### PR TITLE
add wrapper for move-only functors

### DIFF
--- a/src/EventLoopImpl.h
+++ b/src/EventLoopImpl.h
@@ -143,9 +143,30 @@ public:
         err = sync(std::forward<F>(f));
     }
 
+    template<typename F>
+    KMError sync(F &&f)
+    {
+        wrapper<F> wf{std::forward<F>(f)};
+        return sync(Task(std::move(wf)));
+    }
     KMError sync(Task task);
+
+    template<typename F>
+    KMError async(F &&f, Token *token=nullptr)
+    {
+        wrapper<F> wf{std::forward<F>(f)};
+        return async(Task(std::move(wf)), token);
+    }
     KMError async(Task task, EventLoopToken *token=nullptr);
+
+    template<typename F>
+    KMError post(F &&f, Token *token=nullptr)
+    {
+        wrapper<F> wf{std::forward<F>(f)};
+        return post(Task(std::move(wf)), token);
+    }
     KMError post(Task task, EventLoopToken *token=nullptr);
+    
     void loopOnce(uint32_t max_wait_ms);
     void loop(uint32_t max_wait_ms = -1);
     void notify();

--- a/src/kmapi.h
+++ b/src/kmapi.h
@@ -149,6 +149,12 @@ public:
      *
      * @param task the task to be executed. it will always be executed when call success
      */
+    template<typename F>
+    KMError sync(F &&f)
+    {
+        wrapper<F> wf{std::forward<F>(f)};
+        return sync(Task(std::move(wf)));
+    }
     KMError sync(Task task);
     
     /* run the task in loop thread.
@@ -158,6 +164,12 @@ public:
      * @param token to be used to cancel the task. If token is null, the caller should
      *              make sure the resources referenced by task are valid when task running
      */
+    template<typename F>
+    KMError async(F &&f, Token *token=nullptr)
+    {
+        wrapper<F> wf{std::forward<F>(f)};
+        return async(Task(std::move(wf)), token);
+    }
     KMError async(Task task, Token *token=nullptr);
     
     /* run the task in loop thread at next time.
@@ -166,6 +178,12 @@ public:
      * @param token to be used to cancel the task. If token is null, the caller should
      *              make sure the resources referenced by task are valid when task running
      */
+    template<typename F>
+    KMError post(F &&f, Token *token=nullptr)
+    {
+        wrapper<F> wf{std::forward<F>(f)};
+        return post(Task(std::move(wf)), token);
+    }
     KMError post(Task task, Token *token=nullptr);
     
     /* cancel the tasks that are scheduled with token. you cannot cancel the task that is in running,
@@ -296,6 +314,12 @@ public:
     /**
      * Schedule the timer. This API is thread-safe
      */
+    template<typename F>
+    bool schedule(uint32_t delay_ms, TimerMode mode, F &&f)
+    {
+        wrapper<F> wf{std::forward<F>(f)};
+        return schedule(delay_ms, mode, TimerCallback(std::move(wf)));
+    }
     bool schedule(uint32_t delay_ms, TimerMode mode, TimerCallback cb);
     
     /**

--- a/src/kmtraits.h
+++ b/src/kmtraits.h
@@ -1,0 +1,41 @@
+// 
+// Functor wrapper for move-only objects
+// https://stackoverflow.com/questions/25330716/move-only-version-of-stdfunction
+//
+#pragma once
+
+#include <type_traits>
+
+KUMA_NS_BEGIN
+
+template<typename Fn, typename En = void>
+struct wrapper;
+
+template<typename Fn>
+struct wrapper<Fn, std::enable_if_t< std::is_copy_constructible<Fn>{} >>
+{
+    Fn fn;
+
+    template<typename... Args>
+    auto operator()(Args&&... args) { return fn(std::forward<Args>(args)...); }
+};
+
+template<typename Fn>
+struct wrapper<Fn, std::enable_if_t< !std::is_copy_constructible<Fn>{}
+    && std::is_move_constructible<Fn>{} >>
+{
+    Fn fn;
+
+    wrapper(Fn &&fn) : fn(std::forward<Fn>(fn)) { }
+
+    wrapper(wrapper&&) = default;
+    wrapper& operator=(wrapper&&) = default;
+
+    wrapper(const wrapper& rhs) : fn(const_cast<Fn&&>(rhs.fn)) { throw 0; }
+    wrapper& operator=(wrapper&) { throw 0; }
+
+    template<typename... Args>
+    auto operator()(Args&&... args) { return fn(std::forward<Args>(args)...); }
+};
+
+KUMA_NS_END


### PR DESCRIPTION
fix compile error when pass move-only functors to EventLoop::sync